### PR TITLE
Spell DC clarification

### DIFF
--- a/src/markdown/microluxe20_handbook.md
+++ b/src/markdown/microluxe20_handbook.md
@@ -176,7 +176,7 @@ There is no need to memorize spells in advance. Just because a character can cas
 
 **Spell Difficulty Class (DC)** for all spells: 10 + Caster Level + Caster's MIND bonus
 
-When a spell is cast, the target of the spell must make a DC save (d20), unless the spell states that it requires a different save. If the target scores lower than the spell's DC, they are affected by the spell.
+When a spell is cast, the target of the spell must make a relevant DC save (d20 + relevant stat bonus), unless the spell states that it requires a different or more specific save. If the target scores lower than the spell's DC, they are affected by the spell. For example, if the spell forms spikes that protrude from the ground, the target may make a DEX save to try and escape the spell's effects. 
 
 Here are three ways for spell casters to add a little more variety:
 


### PR DESCRIPTION
I went ahead and added a little bit of clarification to the super generic 'DC save' for spell difficulty class rolls. This includes a quick example as well. This should help explain #23 a little bit more. @Web-eWorks , let me know if this helps any, or if you'd prefer a different direction altogether.