### PR TITLE
Update 1.9.0, part 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ release/*
 node_modules/*
 .tmp-*
 *.code-workspace
+/.vscode

--- a/README.md
+++ b/README.md
@@ -40,13 +40,11 @@ If you want to contribute to the game's handbooks, or want to craft your own cus
 
 # Authors & Contributors
 
-Keli Grubb (<keligrubb324@gmail.com>)
-
-Doug Rich
-
-Connor Bashinski
-
-Webster Sheets
+- Keli Grubb, Author (<keligrubb324@gmail.com>)
+- Webster Sheets, Maintainer
+- Doug Rich
+- Connor Bashinski
+- João Gabriel Moritz Lima
 
 # Licensing
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,7 @@ const config = {
   paperFormat: 'Letter',
 
   compiledOut: [
-    ['handbook', 'equipment', 'spells'],
+    ['handbook', 'equipment', 'classes'],
     ['gm_guide'],
     ['lore'],
     ['races'],

--- a/src/data/gear.yml
+++ b/src/data/gear.yml
@@ -9,6 +9,7 @@ data:
     - Antitoxin (vial) | 50gp
     - Artisan's Tools | 5gp
     - Backpack (empty) | 2gp
+    - Bandages (roll of 10) | 1gp
     - Barrel (empty, 40 gal.) | 2gp
     - Basket (empty) | 4sp
     - Bedroll | 1sp
@@ -18,7 +19,7 @@ data:
     - Bottle, glass (empty, 2 pt.) | 2gp
     - Bucket (empty, 2 gal.) | 5sp
     - Caltrops | 1gp
-    - Candle | 1cp
+    - Candle (pack of 10) | 1sp
     - Canvas (sq. yd.) | 1sp
     - Case, map or scroll | 1gp
     - Chain (10 ft.) | 30gp
@@ -33,7 +34,8 @@ data:
     - Flask (empty, ½ pt.) | 3cp
     - Grappling Hook | 1gp
     - Hammer | 5sp
-    - Healer's Kit | 50gp
+    - Healer's Kit (25 uses) | 50gp
+    - Herbal Tea (10 uses) | 10gp
     - Holy Symbol, wooden | 1gp
     - Holy Symbol, silver | 25gp
     - Holy Water (flask) | 25gp

--- a/src/data/races.yml
+++ b/src/data/races.yml
@@ -21,5 +21,5 @@ data:
     - "**Elvir** | +1 DEX, and +1 to any 1 Skill"
     - "**Orkeir** | +2 STR, -1 MIND, +1 to Physical skill"
     - "**Tauremir** | +2 STR, -1 MIND,  +1 to any 1 Skill"
-    - "**Gorimir** | a +1 DEX, and +1 to any 1 Skill"
+    - "**Gorimir** | +1 DEX, and +1 to any 1 Skill"
     - "**Slaan** | +2 MIND, +1 DEX, -1 to STR"

--- a/src/markdown/microluxe20_classes.md
+++ b/src/markdown/microluxe20_classes.md
@@ -456,7 +456,7 @@ Entertainers, scoundrels, sages, tricksters, historians, and bartenders all in o
 
 Psions are strange quirks of nature whose minds are warped from birth. They posess a natural connection with the Ethereal Plane, which allows them to directly project power into their surroundings. This often results in Psions perceiving the world in strange ways, and developing anti-social and amoral tendencies due to their outcast status.
 
-Psions cannot not use staves, rods, or metamagic. Instead, their powers are augmented with additional Hit Points (HP). The augmenting HP cost is noted under each power's entry. The combined HP cost for manifesting and augmenting a power (disregarding signature spell bonus) cannot exceed the character's psionic class level. Thus, a 3rd level psion could manifest a level 2 power by spending 2 HP, and augment it with at most 1 additional HP for a total HP cost of 3.
+Psions cannot not use staves, rods, or metamagic. Instead, their powers are augmented with additional Magic Points (MP). The augmenting MP cost is noted under each power's entry. The combined MP cost for manifesting and augmenting a power (disregarding signature spell bonus) cannot exceed the character's psionic class level. Thus, a 3rd level psion could manifest a level 2 power by spending 2 MP, and augment it with at most 1 additional MP for a total MP cost of 3.
 
 _Psionic vs. Magical Effects_: Powers interact with spells and spells interact with powers in the same way a spell or normal spell-like ability interacts with another spell or spell-like ability. For example, detect magic detects psionics and dispel psionics dispels magic. After casting a spell, a Psion is under the effects of Ethereal Influence, which functions the same as Arcane Influence.
 

--- a/src/markdown/microluxe20_classes.md
+++ b/src/markdown/microluxe20_classes.md
@@ -2,9 +2,9 @@
 
 # Classes, Spells, and Powers
 
-The following spells and powers have been customized and tweaked to make the game as smooth as possible. It is suggested to use these spells for all spell casters in the game, although spells from the SRD can also be used in Microluxe20 with slight modifications. With the following spell system in place, additional spells in the SRD (but not on this list) can easily be discovered in the game as loot, research, etc. if the GM desires.
-
 Each class has a brief description, a list of their abilities and the minimum level for each ability, and a list of spells that class can cast divided by caster level.
+
+The following spells and powers have been customized and tweaked to make the game as smooth as possible. It is suggested to use these spells for all spell casters in the game, although spells from the SRD can also be used in Microluxe20 with slight modifications. With the following spell system in place, additional spells in the SRD (but not on this list) can easily be discovered in the game as loot, research, etc. if the GM desires.
 
 ## Fighter
 
@@ -34,17 +34,17 @@ Mages are perhaps the simplest of spellcasters, working their craft of science a
 
 **Equipment**: Mages wear no armor, cannot use shields, and can only use simple weapons.
 
-**Detect Magic:** Detects spells and magic items within 60 ft. at will. A roll may be required to detect magic that is actively being hidden.
+**Read Magic**: Mages can decipher scrolls, spellbooks, and magical inscriptions (at the rate of one page per minute) without invoking the magic contained in the writing. Using this ability on a cursed item may accidentally activate it.
 
-<!-- $page-break -->
+**Dispel Magic** (lv 5): A Mage may cancel a magical spell or effect, dispell a summoned creature, or suppress the effects of a magical item (for 1d4 rounds) with a successful Magic Attack roll against the target Spell Difficulty Class. This can be attempted `1 + Level + MIND bonus` times per day.
 
 ### 1st-Level Arcane Spells: Cantrips
 - **Arcane Mark:**  Inscribes a permanent personal rune (visible or invisible).
+- **Detect Magic:**  Detects spells and magic items within 60 ft. for up to 10 rounds/level or until concentration ends.
 - **Ghost Sound:**  Figment sounds for 1 round/level.
 - **Light:**  Object shines like a torch for 10 min./level.
 - **Mage Hand:**  5-pound telekinesis. Lasts until concentration ends.
 - **Prestidigitation:**  Performs minor tricks for 1 hour.
-- **Read Magic:**  Read scrolls and spellbooks for 10 min./level.
 
 ### 2nd-Level Arcane Spells
 - **Feather Fall:**  Objects or creatures fall slowly for 1 round/level or until landing.
@@ -64,7 +64,6 @@ Mages are perhaps the simplest of spellcasters, working their craft of science a
 
 ### 6th-Level Arcane Spells
 - **Clairvoyance:**  Hear or see at a distance up to 100 ft. for 10 rounds/level.
-- **Dispel Magic:**  Cancels a magical spell or effect.
 - **Fireball:**  Creates a minor explosion up to 60ft. away in an area with a 10ft. radius, dealing 1d6 fire damage/level.
 - **Fly:**  Subject flies at speed of 60 ft. for 10 rounds/level.
 - **Lightning Bolt:**  Summons a bolt of lightning from the caster's hands, dealing 3d8 + 1/level damage.
@@ -118,15 +117,19 @@ Mages are perhaps the simplest of spellcasters, working their craft of science a
 - **Power Word Kill:** Kills one creature with 250 HP or less.
 - **Soul Bind:**  Traps a newly dead soul inside an item, preventing resurrection.
 
+<!-- $page-break -->
+
 ## Cleric
 
 Clerics cast spells by praying to their deity, receiving their answers in the form of manifestations of divine power.
 
-Clerics may lose their ability to cast spells if they blaspheme against their deity or take deliberate action against their deity's morals or values. If this happens, they may regain their ability to cast spells by another Cleric casting Atonement or by personally taking action to repair their standing with their deity.
+Clerics may lose their ability to cast spells if they blaspheme against their deity or take deliberate action against their deity's morals or values. If this happens, they may regain their ability to cast spells through convincing another Cleric to cast Atonement or by personally taking action to repair their standing with their deity.
 
 **Equipment**: Clerics can wear light or medium armor, can not use shields, and can use simple weapons.
 
-**Turn Undead**: Good-aligned Clerics may repel or destroy Undead creatures, while Evil-aligned Clerics may bolster or control Undead with this ability. The Cleric makes a Magic Attack, using the current HP of the Undead as the DC. If the DC is exceeded by 10 it is destroyed/controlled, otherwise it is repelled/bolstered. This can be used (2 + Level + MIND Bonus) times per day.
+**Turn Undead**: Good-aligned Clerics may repel or destroy Undead creatures, while Evil-aligned Clerics may bolster or control Undead with this ability. The Cleric makes a Magic Attack, using the current HP of the Undead as the DC. If the DC is exceeded by 10 it is destroyed/controlled, otherwise it is repelled/bolstered. This can be used `2 + Level + MIND Bonus` times per day.
+
+**Holy Wrath** (lv 5): When attacking Evil creatures (Holy creatures if an Evil-aligned Cleric), Clerics add their Communication skill to the damage of their first attack. Sub-attacks and additional attacks that turn do not receive a _Holy Wrath_ bonus.
 
 ### 1st-Level Divine Spells: Orisons
 - **Create Water:** Creates 2 gallons/level of pure water.
@@ -145,7 +148,7 @@ Clerics may lose their ability to cast spells if they blaspheme against their de
 - **Shield of Faith:** Aura grants +2 or higher AC bonus for 10 rounds/level.
 
 ### 4th-Level Divine Spells
-- **Aid:** +1 on attack rolls and saves against fear, 1d8 temporary HP +1/level (max +10).
+- **Aid:** Target gains +1 on attack rolls and saves against fear, and 1d8 temporary HP +1/level (max +10). The effects last for 10 rounds/level.
 - **Cure Moderate Wounds:** Cures 2d8 damage +1/level (max +10).
 - **Delay Poison:** Stops poison from harming subject for 3 rounds.
 - **Gentle Repose:** Preserves one corpse (or part of a corpse), so that it does not decay. Lasts for 1 day.
@@ -167,8 +170,6 @@ Clerics may lose their ability to cast spells if they blaspheme against their de
 - **Neutralize Poison:**  Immunizes subject against poison for 10 min./level, detoxifies venom in or on subject.
 - **Restoration:**  Restores any level and ability score drains.
 - **Tongues:**  Speak any language for 10 min./level.
-
-<!-- $page-break -->
 
 ### 10th-Level Divine Spells
 - **Atonement:**  Removes burden of misdeeds from subject (ex: a druid who has used metal objects can be forgiven by his/her deity).
@@ -202,6 +203,8 @@ Clerics may lose their ability to cast spells if they blaspheme against their de
 - **Fire Storm:**  Deals 1d6/level fire damage.
 - **Holy Aura:**  +4 to AC, +4 resistance, and spell resistance of 25 against evil spells (the enemy must roll higher than a 25 just to cast the spell) for 1 round/level.
 
+<!-- $page-break -->
+
 ### 18th-Level Divine Spells
 - **Astral Projection:** Projects you and companions onto the Astral Plane. The Astral plane is the space/plane in which Terador (and other worlds) reside. Filled with a thick air-like substance called "miasma", the Astral plane is a timeless plane with ever-changing gravity, known for its magic production.
 - **Etherealness:**  Travel to the Ethereal Plane with companions for 10 rounds/level.
@@ -210,25 +213,25 @@ Clerics may lose their ability to cast spells if they blaspheme against their de
 - **Implosion:**  Kills one creature with 150 HP or less per round for 4 rounds or until concentration ends.
 - **Soul Bind:**  Traps a newly dead soul inside an item, preventing resurrection.
 
-<!-- $page-break -->
-
 ## Paladin
 
 Champions of a specific deity, Paladins are temple guards or armored crusaders sworn to uphold the virtues and beliefs of their religion. For their loyal service, they are granted divine blessings to better carry out their duties.
 
-Like Clerics, Paladins can fall out of favor with their deity, muddying their sense of good and evil, and loosing the ability to cast divine spells.
+Like Clerics, Paladins can fall out of favor with their deity, muddying their ability to detect good or evil and loosing the ability to cast divine spells.
 
 **Equipment**: Paladins wear and use any kind of armor, shield, and weapon.
 
 **Hardy Constitution**: Paladins are immune to diseases and apply a +1 bonus to all saving throws. Tthis increases by +1 at 5th level and every 5 levels onward.
 
-**Detect Evil**: Paladins can attempt to detect evil items or persons within 60ft. at will. A MIND save (vs. a GM-set DC) may be required to detect evil that is actively being hidden. If the Paladin is pledged to an Evil deity, this power becomes Detect Good.
+**Detect Evil**: Paladins can attempt to detect evil items or persons within 60ft. at will. A MIND save may be required to detect evil that is actively being hidden. If the Paladin is pledged to an Evil deity, this power becomes Detect Good.
 
-**Laying on Hands**: A Paladin can heal another character 2 × Level HP up to three times per day by placing their hands on an injured character and praying. _Laying on Hands_ ignores Arcane / Divine influence, healing the maximum amount regardless of whether the target is a spellcaster.
+**Laying on Hands**: A Paladin can heal another character `2 × Level` HP up to three times per day by placing their hands on an injured character and praying. _Laying on Hands_ ignores Arcane / Divine influence, healing the maximum amount regardless of whether the target is a spellcaster.
 
-**Divine Favor** (lv 5): Once per day, a Paladin may choose one 4th-Level and two 2nd-Level Cleric spells, which they may cast until the end of that day. The chosen spells are cast as normal for a Cleric of the appropriate level. This ability is immediately lost if the paladin falls out of favor with their deity.
+**Divine Favor** (lv 5): Once per day, a Paladin may choose one 4th-Level and two 2nd-Level Cleric spells, which they may cast until the end of that day. The chosen spells are cast as normal for a Cleric of the same level. This ability is immediately lost if the paladin falls out of favor with their deity.
 
 ## Ranger
+
+Excellent hunters and scouts, Rangers are known for their mastery of the bow, their skill in campcraft, and their ability to survive and thrive well away from any signs of civilization.
 
 Hidden away in the treetops, invisible on the plains, and silent in the forest loam, Rangers spend many weeks at a time prowling the open lands, hunting what they need to survive, and purging the forests of their more unsavory occupants.
 
@@ -236,7 +239,11 @@ Hidden away in the treetops, invisible on the plains, and silent in the forest l
 
 **Ranged Weapon Proficiency**: Rangers gain +1 to attack and damage rolls with ranged weapons. They only incur a -1 penalty when fighting with two light weapons.
 
+**Endurance**: Rangers gain +2 on skill checks when running, swimming and holding their breath, and +2 on saves against environmental damage and damage from suffocation.
+
 **Trapper** (lv 5): Rangers gain +2 when dealing with traps. This includes setting, searching for, disarming, and hunting with traps, among other uses.
+
+<!-- $page-break -->
 
 ## Illusionist
 
@@ -244,13 +251,18 @@ Illusionists focus their arcane power into creating phantasms of will and tricki
 
 **Equipment**: Illusionists wear no armor, can not use shields, and can only use simple weapons.
 
-**Detect Illusions:** Detects Illusions in a 60ft. radius at will. A MIND save (vs. a GM-set DC) may be required to detect illusions that are actively being hidden.
+**Illusory Script**: With the use of a special ink, an Illusionist can hide a written message or scroll with magic, making it appear to be blank or an entirely different message to all others but you and the recipients you designate. Dispell Magic erases both the original message and the illusion. The ink required for Illusory Script costs 10 gp per use.
+
+**Mesmerizing Shards** (lv 5): An Illusionist can forcefully shatter all Mirror Image decoys they have created into ethereal shards, dealing 2d6 + 1/level mental damage to each creature that is currently fascinated by the caster. (DC 16 MIND save for ½ damage.) This can be done `2 + Level + MIND bonus` times per day.
+
+Creatures that have been fascinated by an illusionist take no actions and have a -4 on all saving throws, but the effect is automatically broken after any attack is made against that creature.
 
 ### 1st-Level Illusionist Spells: Cantrips
 - **Arcane Mark:** Inscribes a permanent personal rune (visible or invisible).
 - **Dancing Lights:** Creates torches or other lights for 10 min./level.
 - **Ghost Sound:** Figment sounds for 1 round/level.
 - **Prestidigitation:** Performs minor tricks for 1 hour.
+- **Detect Illusions:** Detects the presence of illusions in a 60ft. radius for 10 rounds/level.
 - **Read Magic:** Read Scrolls and Spellbooks for 10 min./level.
 
 ### 2nd-Level Illusionist Spells
@@ -258,7 +270,7 @@ Illusionists focus their arcane power into creating phantasms of will and tricki
 - **Color Spray:** Blinds creatures within a 15ft. cone, incapacitating them for 1 round.
 - **Disguise Self:** Changes your appearance for 10 min./level.
 - **Hypnotism:** Fascinates creatures within 15 points of your HP or less for 1d4 rounds.
-- **Silent Image:** Creates a minor illusion of your design.
+- **Silent Image:** Creates a minor, purely visual illusion of your design.
 - **Ventriloquism:** Gain the ability to control one limb of a subject for 1 round.
 
 ### 4th-Level Illusionist Spells
@@ -267,7 +279,7 @@ Illusionists focus their arcane power into creating phantasms of will and tricki
 - **Hypnotic Pattern:** Fascinate creature within 15 points of your HP or less for  1d8 rounds.
 - **Invisibility:** Subject is invisible for 10 rounds/level or until it attacks.
 - **Shadow Blade:** Creates an illusory shadow sword, dealing 3d6 + 1/level damage, with a range of 60ft.
-- **Mirror Image:** Creates 1d4+1 decoys of caster for 10 rounds/level.
+- **Mirror Image:** Creates 1d4+1 decoys of caster for 10 rounds/level. These intangible decoys constantly move within 10 ft, cannot be distinguished from the caster, and are destroyed if attacked.
 
 ### 6th-Level Illusionist Spells
 - **Daylight:** Creates an area with a 60ft. radius of daylight for 10 min./level.
@@ -334,7 +346,7 @@ Druids must forgo the use of weapons and armor made of metal worked by mortal ha
 
 **Equipment**: Druids wear any non-metal armor, can use non-metal shields, and can use simple weapons.
 
-**Woodland Walker**: Druids are immune to the spell-like effects of woodland fey, and gain +1 to stealth rolls in forests.
+**Woodland Traveller**: Druids are immune to the spell-like effects of woodland fey, and gain +1 to stealth rolls in forests.
 
 **Pass Without Trace** (lv 3): Druids can travel without leaving any scent, footprints, or anything else that could be used to trace where they travelled.
 
@@ -345,7 +357,7 @@ Druids must forgo the use of weapons and armor made of metal worked by mortal ha
 - **Detect Magic:**  Detects spells and magic items within 60ft. For 10 rounds/level.
 - **Detect Poison:**  Detects poison in one creature or object.
 - **Mending:**  Makes minor repairs on an object.
-- **Read Magic:**  Read scrolls and spell books.
+- **Read Magic:**  Read Scrolls and Spellbooks for 10 min./level.
 - **Resistance:**  Subject gains +1 on saving throws for 10 rounds.
 
 ### 2nd-Level Druid Spells
@@ -355,6 +367,8 @@ Druids must forgo the use of weapons and armor made of metal worked by mortal ha
 - **Obscuring Mist:**  Fog surrounds your immediate vicinity (10ft.), providing concealment for 1 round/level.
 - **Produce Flame:**  3d6 damage +1/level, touch or thrown.
 - **Speak with Animals:**  You can communicate with animals for 10 rounds/level.
+
+<!-- $page-break -->
 
 ### 4th-Level Druid Spells
 - **Barkskin:**  Grants +2 bonus to AC for 10 min./level.
@@ -380,8 +394,6 @@ Druids must forgo the use of weapons and armor made of metal worked by mortal ha
 - **Repel Vermin:**  Insects, spiders, and other vermin stay 10ft. away for 10 min./level.
 - **Spike Stones:** All creatures within 20ft. take 3d8 damage. They must make a reflex save. If failed, they are slowed.
 
-<!-- $page-break -->
-
 ### 10th-Level Druid Spells
 - **Awaken:**  One animal or tree gains human intellect (4 Mind).
 - **Baleful Polymorph:**  Transforms subject into a harmless animal.
@@ -397,6 +409,8 @@ Druids must forgo the use of weapons and armor made of metal worked by mortal ha
 - **Stone Tell:**  Talk to natural or worked stone for 10 rounds/level.
 - **Transport via Plants:**  Instantly move once from one plant to another as long as the plants are the same type.
 - **Wall of Stone:**  Creates a shape-able wall of stone up to 5ft./level.
+
+<!-- $page-break -->
 
 ### 14th-Level Druid Spells
 - **Changestaff:** Your staff becomes a treant on command.
@@ -436,64 +450,7 @@ Entertainers, scoundrels, sages, tricksters, historians, and bartenders all in o
 
 **Amateur Magician** (lv 6): A Bard may cast spells as if they were either an Illusionist or Druid of 5 levels below their own. The choice of spellcasting class is permanent and cannot be changed.
 
-## Necromancer
-
-Perhaps the most secretive of classes found on Terador, necromancers specialize in mastery of the undead, summoning skeletal remains to do their bidding. This makes them extremely unpopular with Good-aligned Clerics and Paladins, and as a result they are usually found in hidden workshops atop a mountain or deep underground.
-
-**Equipment**: Necromancers wear light armor, can not use shields, and can only use simple weapons. They typically carry necromantic foci of some kind (bones,  scraps of leather, or similar death-aligned objects), a spellbook for recording summonning rituals, and a spellstave.
-
-**Undead Control**: A Necromancer can control summoned undead as if they were a second body. These undead are controlled by the player as additional characters, and may take any action the Game Master rules they are capable of. Uncontrolled undead are automatically hostile and are under the control of the GM. Undead Control starts at 2 Undead, increasing by +1 every 5 levels (5, 10, 15, etc.)
-
-**Summon Undead**: Necromancers specialize in the summoning and control of undead like zombies and animated skeletons. To summon an undead, a necromancer must cast the appropriate spell and have a focus, such as a bone or a limb. The focus limits the type of undead that can be summoned; a necromancer cannot summon a goblin zombie if they only have a bone from a black bear, and they can't summon a black bear zombie if there are no dead black bears in the area. The resulting undead may have traits based on its previous form as determined by the Game Master.
-
-**Detect Undead**: Years of careful practice allow a Necromancer to determine, after some scrutiny, whether a creature is alive or undead. Detect Undead has a range of 60ft. and may be used at will. A MIND save (vs. a GM set DC) may be required to detect Undead that are actively hiding their state.
-
-### 1st-Level Necromancer Spells
-
-- **Cloud of Darkness:** Create a small pocket of magical darkness within 10ft. The cloud is no larger than a human head, and lasts for 10 rounds / level.
-- **Ghostly Hand:** Gain an extra semi-corporeal hand for 10 rounds / level. This hand is incapable of holding more than 5 pounds and cannot make an attack.
-- **Analyse Creature:** +1 to one attack or damage roll per turn against the scanned creature for 5 rounds / level.
-- **Read Magic:** Read Scrolls and Spellbooks for 10 min./level.
-
-### 2nd-Level Necromancer Spells
-
-- **Summon Skeleton:** Animate the skeleton of a medium-sized creature, creating a 1 HD Skeleton with all Stat Bonuses at -2. The undead lasts for 10 min./level or until dispelled. This spell costs a minimum of 1 HP, even as a Signature Spell.
-- **Bone Armor:** Spectral bone armor surrounds the caster, granting +2 AC. The summoned armor lasts for 10 rounds / level.
-- **
-
-### 4th-Level Necromancer Spells
-
-- **Summon Zombie:** Animate the flesh of a recently deceased medium-sized creature, creating a 2 HD Zombie with all Stat Bonuses at -1. The zombie deals 1d6 damage with a successful attack and lasts for 1 hour / level or until dispelled.
-
-### 6th-Level Necromancer Spells
-
-- **Summon Ghoul:** Animate a recently deceased sentient creature, creating a 3 HD Ghoul with all Stat Bonuses at -1. The ghoul deals 1d6+1 damage plus 1d3 rounds of paralysis with a successful hit, and uses 2 Undead Control slots. The ghoul lasts for 1 hour / level.
-- **Bone Wall:** Summon a 10-foot tall wall of sharpened bones (DC 12 DEX save to avoid being impaled). The wall blocks all melee and projectile attacks, lasts for 10 rounds / level and has 25 HP.
-
-### 8th-Level Necromancer Spells
-
-- **Summon Greater Skeleton:** Animate the skeleton of a larger creature, creating a 3 HD Skeleton with all Stat Bonuses at +1. The skeleton deals 1d8+2 damage on a successful hit and lasts for 1 hour / level.
-
-### 10th-Level Necromancer Spells
-
-- **Summon Shadow:**
-
-### 12th-Level Necromancer Spells
-
-- **Summon Greater Zombie:**
-
-### 14th-Level Necromancer Spells
-
-- **Summon Wraith:**
-
-### 16th-Level Necromancer Spells
-
-- **Summon Death Knight:**
-
-### 18th-Level Necromancer Spells
-
-- **Create Phylactery:** Bind your soul to a fist-size object, turning your body into an Undead under your control. This process takes a full week. If you die, your body is reconstructed by the phylactery over the course of a week.
-
+<!-- $page-break -->
 
 ## Psion
 
@@ -501,9 +458,13 @@ Psions are strange quirks of nature whose minds are warped from birth. They pose
 
 Psions cannot not use staves, rods, or metamagic. Instead, their powers are augmented with additional Hit Points (HP). The augmenting HP cost is noted under each power's entry. The combined HP cost for manifesting and augmenting a power (disregarding signature spell bonus) cannot exceed the character's psionic class level. Thus, a 3rd level psion could manifest a level 2 power by spending 2 HP, and augment it with at most 1 additional HP for a total HP cost of 3.
 
-_Psionic vs. Magical Effects_: Powers interact with spells and spells interact with powers in the same way a spell or normal spell-like ability interacts with another spell or spell-like ability. For example, detect magic detects psionics and dispel psionics dispels magic.
+_Psionic vs. Magical Effects_: Powers interact with spells and spells interact with powers in the same way a spell or normal spell-like ability interacts with another spell or spell-like ability. For example, detect magic detects psionics and dispel psionics dispels magic. After casting a spell, a Psion is under the effects of Ethereal Influence, which functions the same as Arcane Influence.
 
 **Equipment**: Psions can use light armor, can not use shields, and can only use simple weapons.
+
+**Temporal Ripples**: Psions learn to interpret the echoes of their actions manifesting in the Ethereal plane, allowing them to use their Magic Attack bonus (MIND + Level) instead of their Melee Attack bonus when attacking with a light melee weapon.
+
+**Ethereal Conduit** (lv 5): As a Psion uses their powers, tiny wisps of the Ethereal begin to permeate their body. When rolling damage dice for a spell or attack with an ethereal weapon, a Psion may reroll a single '1' per turn.
 
 ### 1st-Level Psion Powers: Mantles
 - **Inkling:** Weakly manifest some psionic power, allowing tiny objects or creatures to be moved unpredictably.
@@ -518,8 +479,6 @@ _Psionic vs. Magical Effects_: Powers interact with spells and spells interact w
 - **Mind Thrust:** Deal 3d6 force damage. _Duration_: Instant. _Augment_: Each extra HP adds 1d6+1 to damage.
 - **Precognition:** Gain +2 bonus to one roll in the future. _Duration_: 10 rounds/level. _Augment_: None.
 
-<!-- $page-break -->
-
 ### 4th-Level Psion Powers
 - **Clairvoyant Sense:** See and hear a distant location. _Duration_: 10 rounds/level. _Augment_: None.
 - **Cloud Mind:** You erase knowledge of your presence from a target's mind. _Duration_: 10 rounds/level. _Augment_: None.
@@ -527,6 +486,8 @@ _Psionic vs. Magical Effects_: Powers interact with spells and spells interact w
 - **Psionic Identification:** Learn the properties of a psionic item. _Duration_: Instant. _Augment_: None.
 - **Read Thoughts:** Detect the thoughts of creatures in range. _Duration_: Knowledge, up to 10 rounds/level. _Augment_: None.
 - **Sensitivity to Psychic Impressions:** Find out about an area's past. _Duration_: Knowledge, up to 10 min/level. _Augment_: None.
+
+<!-- $page-break -->
 
 ### 6th-Level Psion Powers
 - **Body Adjustment:** You heal 1d12 damage. _Duration_: Instant. _Augment_: Every 2 extra HP heals an extra 1d12.
@@ -552,14 +513,15 @@ _Psionic vs. Magical Effects_: Powers interact with spells and spells interact w
 - **Psionic Teleportation:** Instantly teleport up to 100 miles/level. _Duration_: Instant. _Augment_: None.
 - **Psionic Sight:** Lets you see all things as they really are (decipher lies, look through secret doors, see through illusions, sense objects in the dark. etc). _Duration_: 10 rounds/level. _Augment_: None.
 
-<!-- $page-break -->
-
 ### 12th-Level Psion Powers
 - **Mass Cloud Mind:** Erase knowledge of your presence from the minds of one creature/level. _Duration_: 10 rounds/level. _Augment_: None.
 - **Retrieve:** Teleport an item in your sight weighing 10lbs. or smaller directly into your hand. If an opponent has the item, it teleports only if the foe fails a Will save. _Duration_: Instant. _Augment_: Every 4 extra HP increases weight allowance by 10lbs.
 - **Crystallize:** Turns a subject into crystal. The subject appears to be lifeless, but is not dead. Dispelling psionics or spells can return to the subject to its previous state (non-crystal). _Duration_: Permanent. _Augment_: None.
 - **Null Psionics Field:** Create a field where psionic power does not function. _Duration_: 10 min/level. _Augment_: None.
 - **Metabolize:** Restores level and stats from drains. _Duration_: Permanent. _Augment_: None.
+
+<!-- $page-break -->
+
 - **Temporal Acceleration:** Your time frame accelerates for 1 round, making you speed up so much that everything else seems motionless. While Accelerated, you may use 2 actions and movements instead of 1 on each round. _Duration_: 1 round. (apparent time). _Augment_: Every 4 extra HP raises duration by 1 round.
 
 ### 14th-Level Psion Powers
@@ -580,3 +542,66 @@ _Psionic vs. Magical Effects_: Powers interact with spells and spells interact w
 - **Psionic Etherealness:** You and 1 creature/3 levels become ethereal. _Duration_: 10 rounds/level. _Augment_: None.
 - **Microcosm:** One creature (100 HP or less) or a group of creatures (each 30 HP or less, totaling to 300 HP maximum) is indefinitely trapped inside a world of its own imagination (no saving throw). _Duration_: Instant. _Augment_: Each extra HP raises the hit point limit of target by 10.
 - **Timeless Body:** Ignore all harmful, and helpful, effects for 1 round. _Duration_: 1 round. _Augment_: None.
+
+<div style="display: none">
+<!-- Necromancer Class currently under construction, hidden for now. -->
+
+## Necromancer
+
+Perhaps the most secretive of classes found on Terador, necromancers specialize in mastery of the undead, summoning skeletal remains to do their bidding. This makes them extremely unpopular with Good-aligned Clerics and Paladins, and as a result they are usually found in hidden workshops atop a mountain or deep underground.
+
+Necromancers specialize in the summoning and control of undead like zombies and animated skeletons. Casting an undead summoning spell requires the use of a magical focus and a suitable corpse the caster has access to. The resulting undead is under the Necromancer's control, and may have traits based on its previous form as determined by the Game Master.
+
+**Equipment**: Necromancers wear light armor, can not use shields, and can only use simple weapons. They typically carry necromantic foci of some kind, a spellbook for recording summonning rituals, and a spellstave.
+
+**Undead Control**: Summoned undead are controlled by the Necromancer, and may take actions as if they were regular characters. Summoned undead always have an Initiative of 1. A Necromancer may only control 1 Undead at a time, increasing by +1 every 5 levels (5, 10, 15, etc.). Once an Undead is no longer controlled by a Necromancer, it is hostile and cannot be controlled again.
+
+**Detect Undead**: A Necromancer can detect the presence of Undead creatures within 60ft at will. A MIND save (vs. a GM set DC) may be required to detect hidden Undead or those behind a glamour.
+
+### 1st-Level Necromantic Spells
+
+- **Cloud of Darkness:** Create a small pocket of magical darkness within 10ft. The cloud is no larger than a human head, and lasts for 10 rounds / level.
+- **Ghostly Hand:** Gain an extra semi-corporeal hand for 10 rounds / level. This hand is incapable of holding more than 5 pounds and cannot make an attack.
+- **Analyse Creature:** +1 to one attack or damage roll per turn against the scanned creature for 5 rounds / level.
+- **Read Magic:** Read Scrolls and Spellbooks for 10 min./level.
+
+### 2nd-Level Necromantic Spells
+
+- **Summon Skeleton:** Animate the skeleton of a medium-sized creature, creating a 1 HD Skeleton with all Stat Bonuses at -2. The undead lasts for 10 min./level or until dispelled. This spell costs a minimum of 1 HP, even as a Signature Spell.
+- **Bone Armor:** Spectral bone armor surrounds the caster, granting +2 AC. The summoned armor lasts for 10 rounds / level.
+- **
+
+### 4th-Level Necromantic Spells
+
+- **Summon Zombie:** Animate the flesh of a recently deceased medium-sized creature, creating a 2 HD Zombie with all Stat Bonuses at -1. The zombie deals 1d6 damage with a successful attack and lasts for 1 hour / level or until dispelled.
+
+### 6th-Level Necromantic Spells
+
+- **Summon Ghoul:** Animate a recently deceased sentient creature, creating a 3 HD Ghoul with all Stat Bonuses at -1. The ghoul deals 1d6+1 damage plus 1d3 rounds of paralysis with a successful hit, and uses 2 Undead Control slots. The ghoul lasts for 1 hour / level.
+- **Bone Wall:** Summon a 10-foot tall wall of sharpened bones (DC 12 DEX save to avoid being impaled). The wall blocks all melee and projectile attacks, lasts for 10 rounds / level and has 25 HP.
+
+### 8th-Level Necromantic Spells
+
+- **Summon Greater Skeleton:** Animate the skeleton of a larger creature, creating a 3 HD Skeleton with all Stat Bonuses at +1. The skeleton deals 1d8+2 damage on a successful hit and lasts for 1 hour / level.
+
+### 10th-Level Necromantic Spells
+
+- **Summon Shadow:**
+
+### 12th-Level Necromantic Spells
+
+- **Summon Greater Zombie:**
+
+### 14th-Level Necromantic Spells
+
+- **Summon Wraith:**
+
+### 16th-Level Necromantic Spells
+
+- **Summon Death Knight:**
+
+### 18th-Level Necromantic Spells
+
+- **Create Phylactery:** Bind your soul to a fist-size object, turning your body into an Undead under your control. This process takes a full week. If you die, your body is reconstructed by the phylactery over the course of a week.
+
+</div>

--- a/src/markdown/microluxe20_classes.md
+++ b/src/markdown/microluxe20_classes.md
@@ -436,6 +436,65 @@ Entertainers, scoundrels, sages, tricksters, historians, and bartenders all in o
 
 **Amateur Magician** (lv 6): A Bard may cast spells as if they were either an Illusionist or Druid of 5 levels below their own. The choice of spellcasting class is permanent and cannot be changed.
 
+## Necromancer
+
+Perhaps the most secretive of classes found on Terador, necromancers specialize in mastery of the undead, summoning skeletal remains to do their bidding. This makes them extremely unpopular with Good-aligned Clerics and Paladins, and as a result they are usually found in hidden workshops atop a mountain or deep underground.
+
+**Equipment**: Necromancers wear light armor, can not use shields, and can only use simple weapons. They typically carry necromantic foci of some kind (bones,  scraps of leather, or similar death-aligned objects), a spellbook for recording summonning rituals, and a spellstave.
+
+**Undead Control**: A Necromancer can control summoned undead as if they were a second body. These undead are controlled by the player as additional characters, and may take any action the Game Master rules they are capable of. Uncontrolled undead are automatically hostile and are under the control of the GM. Undead Control starts at 2 Undead, increasing by +1 every 5 levels (5, 10, 15, etc.)
+
+**Summon Undead**: Necromancers specialize in the summoning and control of undead like zombies and animated skeletons. To summon an undead, a necromancer must cast the appropriate spell and have a focus, such as a bone or a limb. The focus limits the type of undead that can be summoned; a necromancer cannot summon a goblin zombie if they only have a bone from a black bear, and they can't summon a black bear zombie if there are no dead black bears in the area. The resulting undead may have traits based on its previous form as determined by the Game Master.
+
+**Detect Undead**: Years of careful practice allow a Necromancer to determine, after some scrutiny, whether a creature is alive or undead. Detect Undead has a range of 60ft. and may be used at will. A MIND save (vs. a GM set DC) may be required to detect Undead that are actively hiding their state.
+
+### 1st-Level Necromancer Spells
+
+- **Cloud of Darkness:** Create a small pocket of magical darkness within 10ft. The cloud is no larger than a human head, and lasts for 10 rounds / level.
+- **Ghostly Hand:** Gain an extra semi-corporeal hand for 10 rounds / level. This hand is incapable of holding more than 5 pounds and cannot make an attack.
+- **Analyse Creature:** +1 to one attack or damage roll per turn against the scanned creature for 5 rounds / level.
+- **Read Magic:** Read Scrolls and Spellbooks for 10 min./level.
+
+### 2nd-Level Necromancer Spells
+
+- **Summon Skeleton:** Animate the skeleton of a medium-sized creature, creating a 1 HD Skeleton with all Stat Bonuses at -2. The undead lasts for 10 min./level or until dispelled. This spell costs a minimum of 1 HP, even as a Signature Spell.
+- **Bone Armor:** Spectral bone armor surrounds the caster, granting +2 AC. The summoned armor lasts for 10 rounds / level.
+- **
+
+### 4th-Level Necromancer Spells
+
+- **Summon Zombie:** Animate the flesh of a recently deceased medium-sized creature, creating a 2 HD Zombie with all Stat Bonuses at -1. The zombie deals 1d6 damage with a successful attack and lasts for 1 hour / level or until dispelled.
+
+### 6th-Level Necromancer Spells
+
+- **Summon Ghoul:** Animate a recently deceased sentient creature, creating a 3 HD Ghoul with all Stat Bonuses at -1. The ghoul deals 1d6+1 damage plus 1d3 rounds of paralysis with a successful hit, and uses 2 Undead Control slots. The ghoul lasts for 1 hour / level.
+- **Bone Wall:** Summon a 10-foot tall wall of sharpened bones (DC 12 DEX save to avoid being impaled). The wall blocks all melee and projectile attacks, lasts for 10 rounds / level and has 25 HP.
+
+### 8th-Level Necromancer Spells
+
+- **Summon Greater Skeleton:** Animate the skeleton of a larger creature, creating a 3 HD Skeleton with all Stat Bonuses at +1. The skeleton deals 1d8+2 damage on a successful hit and lasts for 1 hour / level.
+
+### 10th-Level Necromancer Spells
+
+- **Summon Shadow:**
+
+### 12th-Level Necromancer Spells
+
+- **Summon Greater Zombie:**
+
+### 14th-Level Necromancer Spells
+
+- **Summon Wraith:**
+
+### 16th-Level Necromancer Spells
+
+- **Summon Death Knight:**
+
+### 18th-Level Necromancer Spells
+
+- **Create Phylactery:** Bind your soul to a fist-size object, turning your body into an Undead under your control. This process takes a full week. If you die, your body is reconstructed by the phylactery over the course of a week.
+
+
 ## Psion
 
 Psions are strange quirks of nature whose minds are warped from birth. They posess a natural connection with the Ethereal Plane, which allows them to directly project power into their surroundings. This often results in Psions perceiving the world in strange ways, and developing anti-social and amoral tendencies due to their outcast status.

--- a/src/markdown/microluxe20_classes.md
+++ b/src/markdown/microluxe20_classes.md
@@ -1,16 +1,45 @@
-<!-- $header Spell Lists -->
+<!-- $header Classes, Spells <br> and Powers -->
 
-# Spell Lists
+# Classes, Spells, and Powers
 
-The following spells have been customized and tweaked to make the game as smooth as possible. It is suggested to use these spells for all spell casters in the game, although spells from the SRD can also be used in Microluxe20 with slight modifications. With the following spell system in place, additional spells in the SRD (but not on this list) can easily be discovered in the game as loot, research, etc. if the GM desires.
+The following spells and powers have been customized and tweaked to make the game as smooth as possible. It is suggested to use these spells for all spell casters in the game, although spells from the SRD can also be used in Microluxe20 with slight modifications. With the following spell system in place, additional spells in the SRD (but not on this list) can easily be discovered in the game as loot, research, etc. if the GM desires.
 
-## Arcane Spells (Mage)
+Each class has a brief description, a list of their abilities and the minimum level for each ability, and a list of spells that class can cast divided by caster level.
+
+## Fighter
+
+Fighters are mercenaries, brawlers, muscle-for-hire, wrestlers, dockworkers, or members of any other profession that require strength and skill in equal measure.
+
+**Equipment**: Fighters can use all types of weapon, armor, and shields.
+
+**Weapon Proficiency**: Fighters gain +1 to all attack and damage rolls. This increases by +1 at 5th level and every five levels onward.
+
+**Extremely Healthy**: Each time they level up, Fighters gain HP equal to their STR bonus in addition to the normal HP gained when leveling up.
+
+**Cleave** (lv 5): If a Fighter's melee attack downs or slays a foe, the figher may make one additional melee attack against another target within melee range. This ability can compound, meaning if one swing kills the second foe, the Fighter can make a third attack, and so on.
+
+## Rogue
+
+A Rogue is a master of the urban sprawl, attacking from the shadows and fading away without a trace. Whether aristocrat or commoner, a Rogue is equally at home in a tavern as they are in a high-society function, picking pockets and poisoning drinks just as easily as starting a bar brawl or thanking a noble for his hospitality.
+
+**Equipment**: Rogues can use light armor, can use bucklers, and can use simple weapons and complex light weapons.
+
+**Sneak Attack**: With a successful sneak check (usually Guile+DEX), Rogues add their Guile skill to the damage of their first attack that turn. Sub-attacks and additional attacks that turn do not receive a _Sneak Attack_ bonus.
+
+**Evade** (lv 5): Any save that a Rogue succeeds cannot deal damage to the rogue. For example, some spells or abilities deal half-damage even if the target saves successfully. With Evade, the Rogue would not take any damage as long as he/she saved successfully.
+
+## Mage
 
 Mages are perhaps the simplest of spellcasters, working their craft of science and knowledge to channel the energies of the Astral Plane into complex productions of magic. Mages were the first to pioneer the Runic alphabet and tongue, in which scrolls are written and spells are cast.
 
+**Equipment**: Mages wear no armor, cannot use shields, and can only use simple weapons.
+
+**Detect Magic:** Detects spells and magic items within 60 ft. at will. A roll may be required to detect magic that is actively being hidden.
+
+<!-- $page-break -->
+
 ### 1st-Level Arcane Spells: Cantrips
 - **Arcane Mark:**  Inscribes a permanent personal rune (visible or invisible).
-- **Detect Magic:**  Detects spells and magic items within 60 ft. for up to 10 rounds/level or until concentration ends.
 - **Ghost Sound:**  Figment sounds for 1 round/level.
 - **Light:**  Object shines like a torch for 10 min./level.
 - **Mage Hand:**  5-pound telekinesis. Lasts until concentration ends.
@@ -40,8 +69,6 @@ Mages are perhaps the simplest of spellcasters, working their craft of science a
 - **Fly:**  Subject flies at speed of 60 ft. for 10 rounds/level.
 - **Lightning Bolt:**  Summons a bolt of lightning from the caster's hands, dealing 3d8 + 1/level damage.
 - **Vampiric Touch:**  The caster touches a subject, draining away their life force. Deals 1d6 damage per two levels and the caster gains half of the damage as HP.
-
-<!-- $page-break -->
 
 ### 8th-Level Arcane Spells
 - **Animate Dead:**  Creates up to 4 undead skeletons or zombies (requires remains).
@@ -83,8 +110,6 @@ Mages are perhaps the simplest of spellcasters, working their craft of science a
 - **Power Word Stun:** Stuns creature with 150 HP or less for 2d4 rounds.
 - **Trap the Soul:** Imprisons a target's soul and material body within a gem.
 
-<!-- $page-break -->
-
 ### 18th-Level Arcane Spells
 - **Astral Projection:** Projects you and companions onto the Astral Plane. The Astral plane is the space/plane in which Terador (and other worlds) reside. Filled with a thick air-like substance called "miasma", the Astral plane is a timeless plane with ever-changing gravity, known for its magic production.
 - **Etherealness:** Travel to Ethereal Plane with companions for 10 rounds/level.
@@ -93,11 +118,15 @@ Mages are perhaps the simplest of spellcasters, working their craft of science a
 - **Power Word Kill:** Kills one creature with 250 HP or less.
 - **Soul Bind:**  Traps a newly dead soul inside an item, preventing resurrection.
 
-## Divine Spells (Cleric)
+## Cleric
 
-Clerics cast spells by praying to their deity, receiving their answers in the form of manifestations of divine power. Clerics may lose their ability to cast spells if they blaspheme against their deity or take deliberate action against their deity's morals or values.
+Clerics cast spells by praying to their deity, receiving their answers in the form of manifestations of divine power.
 
-Clerics may regain their ability to cast spells by Atonement or taking action to repair their standing with their deity.
+Clerics may lose their ability to cast spells if they blaspheme against their deity or take deliberate action against their deity's morals or values. If this happens, they may regain their ability to cast spells by another Cleric casting Atonement or by personally taking action to repair their standing with their deity.
+
+**Equipment**: Clerics can wear light or medium armor, can not use shields, and can use simple weapons.
+
+**Turn Undead**: Good-aligned Clerics may repel or destroy Undead creatures, while Evil-aligned Clerics may bolster or control Undead with this ability. The Cleric makes a Magic Attack, using the current HP of the Undead as the DC. If the DC is exceeded by 10 it is destroyed/controlled, otherwise it is repelled/bolstered. This can be used (2 + Level + MIND Bonus) times per day.
 
 ### 1st-Level Divine Spells: Orisons
 - **Create Water:** Creates 2 gallons/level of pure water.
@@ -139,6 +168,8 @@ Clerics may regain their ability to cast spells by Atonement or taking action to
 - **Restoration:**  Restores any level and ability score drains.
 - **Tongues:**  Speak any language for 10 min./level.
 
+<!-- $page-break -->
+
 ### 10th-Level Divine Spells
 - **Atonement:**  Removes burden of misdeeds from subject (ex: a druid who has used metal objects can be forgiven by his/her deity).
 - **Commune:**  Deity answers one yes-or-no question/level. Lasts for 1 round/level
@@ -171,8 +202,6 @@ Clerics may regain their ability to cast spells by Atonement or taking action to
 - **Fire Storm:**  Deals 1d6/level fire damage.
 - **Holy Aura:**  +4 to AC, +4 resistance, and spell resistance of 25 against evil spells (the enemy must roll higher than a 25 just to cast the spell) for 1 round/level.
 
-<!-- $page-break -->
-
 ### 18th-Level Divine Spells
 - **Astral Projection:** Projects you and companions onto the Astral Plane. The Astral plane is the space/plane in which Terador (and other worlds) reside. Filled with a thick air-like substance called "miasma", the Astral plane is a timeless plane with ever-changing gravity, known for its magic production.
 - **Etherealness:**  Travel to the Ethereal Plane with companions for 10 rounds/level.
@@ -181,14 +210,45 @@ Clerics may regain their ability to cast spells by Atonement or taking action to
 - **Implosion:**  Kills one creature with 150 HP or less per round for 4 rounds or until concentration ends.
 - **Soul Bind:**  Traps a newly dead soul inside an item, preventing resurrection.
 
-## Arcane Spells (Illusionist)
+<!-- $page-break -->
+
+## Paladin
+
+Champions of a specific deity, Paladins are temple guards or armored crusaders sworn to uphold the virtues and beliefs of their religion. For their loyal service, they are granted divine blessings to better carry out their duties.
+
+Like Clerics, Paladins can fall out of favor with their deity, muddying their sense of good and evil, and loosing the ability to cast divine spells.
+
+**Equipment**: Paladins wear and use any kind of armor, shield, and weapon.
+
+**Hardy Constitution**: Paladins are immune to diseases and apply a +1 bonus to all saving throws. Tthis increases by +1 at 5th level and every 5 levels onward.
+
+**Detect Evil**: Paladins can attempt to detect evil items or persons within 60ft. at will. A MIND save (vs. a GM-set DC) may be required to detect evil that is actively being hidden. If the Paladin is pledged to an Evil deity, this power becomes Detect Good.
+
+**Laying on Hands**: A Paladin can heal another character 2 × Level HP up to three times per day by placing their hands on an injured character and praying. _Laying on Hands_ ignores Arcane / Divine influence, healing the maximum amount regardless of whether the target is a spellcaster.
+
+**Divine Favor** (lv 5): Once per day, a Paladin may choose one 4th-Level and two 2nd-Level Cleric spells, which they may cast until the end of that day. The chosen spells are cast as normal for a Cleric of the appropriate level. This ability is immediately lost if the paladin falls out of favor with their deity.
+
+## Ranger
+
+Hidden away in the treetops, invisible on the plains, and silent in the forest loam, Rangers spend many weeks at a time prowling the open lands, hunting what they need to survive, and purging the forests of their more unsavory occupants.
+
+**Equipment**: Rangers can wear light or medium armor, can use shields, and can use simple weapons, complex ranged weapons, and complex one-handed weapons.
+
+**Ranged Weapon Proficiency**: Rangers gain +1 to attack and damage rolls with ranged weapons. They only incur a -1 penalty when fighting with two light weapons.
+
+**Trapper** (lv 5): Rangers gain +2 when dealing with traps. This includes setting, searching for, disarming, and hunting with traps, among other uses.
+
+## Illusionist
 
 Illusionists focus their arcane power into creating phantasms of will and tricking others into believing their specific version of the world. For a powerful Illusionist, this can extend even to tricking Reality itself, allowing the caster to travel through solid walls, use shadows as doorways, and much more.
+
+**Equipment**: Illusionists wear no armor, can not use shields, and can only use simple weapons.
+
+**Detect Illusions:** Detects Illusions in a 60ft. radius at will. A MIND save (vs. a GM-set DC) may be required to detect illusions that are actively being hidden.
 
 ### 1st-Level Illusionist Spells: Cantrips
 - **Arcane Mark:** Inscribes a permanent personal rune (visible or invisible).
 - **Dancing Lights:** Creates torches or other lights for 10 min./level.
-- **Detect Illusion:** Detects Illusions in a 60ft. radius for 10 rounds/level.
 - **Ghost Sound:** Figment sounds for 1 round/level.
 - **Prestidigitation:** Performs minor tricks for 1 hour.
 - **Read Magic:** Read Scrolls and Spellbooks for 10 min./level.
@@ -216,8 +276,6 @@ Illusionists focus their arcane power into creating phantasms of will and tricki
 - **Invisibility Sphere:** Makes everyone within 10ft. invisible.
 - **Minor Image:** Creates a minor illusion of your design with sound, smell, and thermal effects.
 - **Suggestion:** Compels subject to follow stated course of action for 1 hour/level or until completed.
-
-<!-- $page-break -->
 
 ### 8th-Level Illusionist Spells
 - **Charm Monster:** Make one monster believe it is your ally for 1 day/level.
@@ -248,6 +306,7 @@ Illusionists focus their arcane power into creating phantasms of will and tricki
 - **Phase Door:** Creates an invisible passage through wood and stone.
 - **Power Word Blind:** Permanently blinds a creature with 200 HP or less.
 - **Prismatic Spray:** Creates a 60ft. Cone-shaped burst of rays causing a variety of effects.
+
 - **Project Image:** Illusory double (with half of the caster's HP) can talk and cast spells at medium range for 1 round/level or until it "dies".
 - **Weird:** A fearsome illusion terrifies all creatures within 30 ft, dealing 5d8 damage.
 
@@ -267,11 +326,19 @@ Illusionists focus their arcane power into creating phantasms of will and tricki
 - **Complete Silence:** A subject becomes completely undetectable by sound.
 - **Figmentation:** Any real object or subject is cast into an unknown location in the Ethereal Plane (The ethereal plane is a separate plane from the material plane, invisible to creatures on the material plane. It is gravity-less and dull; a land of ghosts, shadows, and wisps), making it a shadowy illusion. This spell, can only be cast without penalty the first time. After the first successful casting, if attempted again, the caster has a 50% chance of passing. If the caster fails, he/she is cast into the Ethereal Plane instead, becoming an illusion.
 
-## Divine Spells (Druid)
+## Druid
 
 Druids tend to be reclusive hermits, eschewing the busy life of towns and cities for the simple life of the forests and plains, gaining their powers from their worship of nature deities.
 
 Druids must forgo the use of weapons and armor made of metal worked by mortal hands. Simple baubles and tools with small amounts of metal are not enough to draw their deity's ire, but like Clerics, Druids must spend time returning to the good graces of their deity if they stray.
+
+**Equipment**: Druids wear any non-metal armor, can use non-metal shields, and can use simple weapons.
+
+**Woodland Walker**: Druids are immune to the spell-like effects of woodland fey, and gain +1 to stealth rolls in forests.
+
+**Pass Without Trace** (lv 3): Druids can travel without leaving any scent, footprints, or anything else that could be used to trace where they travelled.
+
+**Wild Form** (lv 7): Up to 3 times per day, a Druid can assume the form of a small-to-medium woodland animal (about the size of a black bear) of their choice. When changing back from _Wild Form_, the Druid heals 2 HP / level.
 
 ### 1st-Level Druid Spells: Orisons
 - **Create Water:**  Creates 2 gallons/level of pure water.
@@ -297,8 +364,6 @@ Druids must forgo the use of weapons and armor made of metal worked by mortal ha
 - **Tree Shape:**  You look exactly like a tree for 1 hour/level.
 - **Warp Wood:**  Bends wood within a 20ft. radius.
 
-<!-- $page-break -->
-
 ### 6th-Level Druid Spells
 - **Call Lightning:**  Calls a lightning storm into an area with a 5ft. radius. Lightning bolts come down from the sky dealing 3d6 + 1/level damage once per round for 1 round/level.
 - **Protection from Energy:**  Absorb 12 points/level of damage from one kind of energy for 10 rounds/level.
@@ -314,6 +379,8 @@ Druids must forgo the use of weapons and armor made of metal worked by mortal ha
 - **Reincarnate:**  Bring back a dead subject into a random body (a body that is nearby).
 - **Repel Vermin:**  Insects, spiders, and other vermin stay 10ft. away for 10 min./level.
 - **Spike Stones:** All creatures within 20ft. take 3d8 damage. They must make a reflex save. If failed, they are slowed.
+
+<!-- $page-break -->
 
 ### 10th-Level Druid Spells
 - **Awaken:**  One animal or tree gains human intellect (4 Mind).
@@ -339,8 +406,6 @@ Druids must forgo the use of weapons and armor made of metal worked by mortal ha
 - **Fire Storm:** Create a blazing storm dealing 1d6/level fire damage to up to a 60ft. radius.
 - **Wind Walk:** You and your allies turn vaporous and travel at up to 60mph for 1 hour/level.
 
-<!-- $page-break -->
-
 ### 16th-Level Druid Spells
 - **Animal Shapes:** One ally/level polymorphs into a chosen animal.
 - **Mass Cure Serious Wounds:** Cures 3d8 damage +1/level for 1 creature/level, no two of which can be more than 30ft. apart.
@@ -357,13 +422,29 @@ Druids must forgo the use of weapons and armor made of metal worked by mortal ha
 - **Summon Nature's Ally:** Summon a 9th-level creature, 1d4 8th-level creatures of the same kind, or 1d4+1 lower-level creatures of the same kind.
 - **Sympathy:** Object or location affected by spell attracts a certain creature type.
 
-## Psionic Powers (Psion)
+## Bard
+
+Entertainers, scoundrels, sages, tricksters, historians, and bartenders all in one, Bards use their musical talent and their ability to make light of outrageous actions to great effect. Where a Rogue is the knife in the shadows, a Bard is a torch, shining so brightly they evade the suspicion of wrongdoing entirely.
+
+**Equipment**: Bards wear light armor, can use bucklers, and can use simple weapons and complex light weapons. They typically carry at least one type of musical instrument, and are skilled at many different types of performances.
+
+**Musical Performance**: With a successful skill check, cancels or counters sound-based effects within 30 ft.
+
+**Charm Person**: Whether by music, dance, or a speech, a Bard can attempt to influence a person by making a performance roll (STR, DEX, or MIND + Communication). The effects of _Charm Person_ are determined by the GM.
+
+**Remove Fear**: As with _Charm Person_, a Bard can encourage and rally a group of people with a performance roll (vs a GM-set DC). A successful roll counters fear-based effects and grants all targets +1 to MIND saves for 1 hr / level.
+
+**Amateur Magician** (lv 6): A Bard may cast spells as if they were either an Illusionist or Druid of 5 levels below their own. The choice of spellcasting class is permanent and cannot be changed.
+
+## Psion
 
 Psions are strange quirks of nature whose minds are warped from birth. They posess a natural connection with the Ethereal Plane, which allows them to directly project power into their surroundings. This often results in Psions perceiving the world in strange ways, and developing anti-social and amoral tendencies due to their outcast status.
 
 Psions cannot not use staves, rods, or metamagic. Instead, their powers are augmented with additional Hit Points (HP). The augmenting HP cost is noted under each power's entry. The combined HP cost for manifesting and augmenting a power (disregarding signature spell bonus) cannot exceed the character's psionic class level. Thus, a 3rd level psion could manifest a level 2 power by spending 2 HP, and augment it with at most 1 additional HP for a total HP cost of 3.
 
-**Psionic vs. Magical Effects:** Powers interact with spells and spells interact with powers in the same way a spell or normal spell-like ability interacts with another spell or spell-like ability. For example, detect magic detects psionics and dispel psionics dispels magic.
+_Psionic vs. Magical Effects_: Powers interact with spells and spells interact with powers in the same way a spell or normal spell-like ability interacts with another spell or spell-like ability. For example, detect magic detects psionics and dispel psionics dispels magic.
+
+**Equipment**: Psions can use light armor, can not use shields, and can only use simple weapons.
 
 ### 1st-Level Psion Powers: Mantles
 - **Inkling:** Weakly manifest some psionic power, allowing tiny objects or creatures to be moved unpredictably.
@@ -377,6 +458,8 @@ Psions cannot not use staves, rods, or metamagic. Instead, their powers are augm
 - **Mindlink:** Forge a limited mental bond with another creature. _Duration_: 10 rounds/level. _Augment_: Every 2 extra HP links another creature.
 - **Mind Thrust:** Deal 3d6 force damage. _Duration_: Instant. _Augment_: Each extra HP adds 1d6+1 to damage.
 - **Precognition:** Gain +2 bonus to one roll in the future. _Duration_: 10 rounds/level. _Augment_: None.
+
+<!-- $page-break -->
 
 ### 4th-Level Psion Powers
 - **Clairvoyant Sense:** See and hear a distant location. _Duration_: 10 rounds/level. _Augment_: None.

--- a/src/markdown/microluxe20_equipment.md
+++ b/src/markdown/microluxe20_equipment.md
@@ -102,3 +102,13 @@ Suggested starting packs for new characters. Each pack uses 35gp of a character'
 <!-- $data gear.yml fast-packs -->
 
 Rogues are advised to purchase Thieves' Tools if they want to pick locks, disarm traps, etc.
+
+### Healing Items
+
+While potions and spells heal characters instantly, they are expensive and ineffective when used on spellcasters. More natural healing remedies are available for purchase, trading an increased healing time for utility and cost-effectiveness.
+
+**Bandages**: Apply one per injured or bleeding limb. Each bandage heals 1d6+1 HP after an hour of rest, at which point they may be safely discarded. A bandage can be improvised from 1 use of Adventuring Gear, or purchased separately.
+
+**Herbal Tea**: A collection of medicinal teas that restore 1d6+2 HP / hour for the next four hours of rest. Herbal tea is packaged in the dry state, and must be brewed before drinking. Drinking more than one cup of tea between rests has no effect.
+
+**Healing Kit**: One use of a Healing Kit stablizes a downed character, immediately restores 1d6 HP, and gives them an additional 1d6+4 HP recovery / hour for the next two hours of rest. Using a healing kit again on a character who hasn't been downed or taken a long rest since the first application has no effect.

--- a/src/markdown/microluxe20_equipment.md
+++ b/src/markdown/microluxe20_equipment.md
@@ -23,7 +23,7 @@ Here is the format for weapon entries (given as column headings on the table bel
 - **Cost:** This value is the price for purchasing the weapon. The cost includes miscellaneous gear that goes with the weapon (For example, buying a bow would include a quiver as well).
 - **Damage:** The damage column gives the damage dealt by the weapon on a successful hit.
 - **Range:** Any attack less than this distance is not penalized. However, every extra 5ft. imposes a -2 penalty on the attack roll.
-- **Complexity:** Different weapons require different amount of training to use. The level of complexity relies on the player's class. For example, Mages cannot use Complex weapons.
+- **Complexity:** Different weapons require different amount of training to use. Characters with martial training can wield Complex weapons, while most spellcasters can only wield Simple weapons.
 
 ### Light Weapons
 

--- a/src/markdown/microluxe20_gm_guide.md
+++ b/src/markdown/microluxe20_gm_guide.md
@@ -16,13 +16,13 @@ The second problem is not so simple. A large part of keeping players interested 
 
 For some characters, these senses will be heightened; a lycan may rely more on their sense of smell than sight, whereas a character with large ears like a goblin may use their hearing more heavily than their other senses.
 
-**Tell a story.** A hack-and-slash campaign is only fun until the monsters run out. Work with your players before a campain to establish an _arc_ for their characters, and weave that arc into the plot of the campaign. An arc can be as simple as a desire or shortcoming the character seeks to fulfill or overcome, or could be a full story with multiple side characters that makes up a large portion of the campaign.
+**Tell a story.** A hack-and-slash campaign is only fun until the monsters run out. Work with your players before a campaign to establish an _arc_ for their characters, and weave that arc into the plot of the campaign. An arc can be as simple as a desire or shortcoming the character seeks to fulfill or overcome, or could be a full story with multiple side characters that makes up a large portion of the campaign.
 
 Encourage your players to come up with something that is just as much fun to interact with from the outside as it is to play from the inside; a character's arc will likely span the majority of a campaign, or even provide the hook for an entire campaign in its own right.
 
 **Work together (or against each other).** Above all, a Role-Playing Game is a type of _cooperative_ game, where the main goal is for players to move through the world and accomplish goals together. While characters should certainly have their own motivations for joining the party (and their own frictions with other characters), encourage your players to work together to make the game fun for everyone.
 
-A game where the party is secretly plotting against each other and moving to foil each other's actions can certainly be buckets of fun with the right players, but make sure to get the approval of the whole table first; losing a character because someone was playing by a different set of rules is a very quick way to sour a player's attitude towards the group as a whole.
+A game where the party is secretly plotting against each other and moving to foil each other's actions can be buckets of fun with the right players, but make sure to get the approval of the whole table first; losing a character because someone was playing by a different set of rules is a very quick way to sour a player's attitude towards the group as a whole.
 
 **Drop some loot!** Half the fun of an RPG like Microluxe20 is in finding new and inventive ways to get weird and quirky items to use, modify, and assemble to get even _more_ shiny and valuable items to get yet _more_... you get the picture. Coming up with new and interesting loot for your players to strive for, and new and interesting uses of items to advance the campaign, will only endear you further to your players.
 

--- a/src/markdown/microluxe20_handbook.md
+++ b/src/markdown/microluxe20_handbook.md
@@ -106,7 +106,11 @@ These three primary stats are used to determine several extremely important seco
 
 **Hit Points (HP)**: Hit Points determine how healthy a character is. As they are injured or hurt, their HP depletes. A character's starting HP is determined with the following formula:
 
-	10 + STR stat + 1d6(with a minimum of 3).
+	10 + STR stat + 1d6(with a minimum of 3)
+
+**Magic Points (MP)**: Magic Points determine how many spells a character can cast before resting. Each spell cast depletes a portion of MP, and characters with no MP cannot cast spells. A character's starting MP is determined with the following formula:
+
+	6 + MIND bonus + 1d3
 
 **Speed** comes in 3 tiers, and determines how far a character can move in a round. Characters are either Slow (20ft.), Normal (30ft.), or Fast (35ft.). A character's Speed is determined by the game master and can be affected by spells and conditions.
 
@@ -114,7 +118,7 @@ Typically, Fighters or Paladins with Heavy armor are Slow, Rogues and Rangers ar
 
 **Armor Class (AC):** A character's Armor Class represents their ability to evade or block physical attacks. The higher a character's AC, the more difficult it is to land a damaging blow. A character's Armor Class is determined by this formula:
 
-	10 + DEX bonus + Armor bonus + Racial bonus (if applicable).
+	10 + DEX bonus + Armor bonus + Racial bonus (if applicable)
 
 **Carrying Capacity:** A character's carrying capacity represents the number and weight of items they are able to easily carry without being overburdened. The capacity is equal to `5 + STR bonus`, and can be increased with a backpack.
 
@@ -134,6 +138,8 @@ The Gamemaster may allow other characters to assist a character when performing 
 
 For compatibility purposes, the 3 saves in Microluxe20 (STR save, DEX save, and MIND save), directly match Fortitude, Reflex, and Will saves (often called "saving throws") found in other SRD-based games. Save rolls may not be assisted by other characters.
 
+<!-- $page-break -->
+
 ## Level Advancement
 
 Characters gain XP (or Experience Points) from defeating monsters, disarming traps, or from handling situations in innovative ways, at the GM's discretion. XP is awarded to all characters who take part in the encounter.
@@ -152,7 +158,9 @@ Regardless of how they are awarded, each level adds:
 
 * +1d6 to Hit Points (with a minimum of 3). Fighters also get additional HP equal to their STR bonus.
 
-* +2 points to spend on skills. When upgrading skills, you cannot add more points to a skill if it is higher than or equal to your character's level + 5.
+* Spellcasters gain additional Magic Points equal to 1d3 + MIND bonus.
+
+* +2 points to spend on skills. When upgrading skills, you cannot add more points to a skill if it is equal to or higher than your character's level + 5.
 
 * Every 3rd level (3, 6, 9, 12, etc.), characters gain +1 STR, DEX, or MIND.
 
@@ -240,15 +248,15 @@ When casting a spell against an inanimate object, the target's MIND bonus is not
 
 If the spell is successfully cast it immediately takes effect, unless the spell states that the target may make a specific save against the spell's effects. For example, a spell that forms spikes that protrude from the ground may allow the target to make a DEX save to try and escape the spell.
 
-Casting a spell of any kind costs Hit Points, regardless of the outcome. The cost is equal to the level of the spell being cast. For example, a 2nd level spell will cost the caster 2 HP.
+Casting a spell of any kind costs Magic Points, regardless of the outcome. The cost is equal to the level of the spell being cast. For example, a 2nd level spell will cost the caster 2 MP.
 
-A spellcaster may cast spells without expending HP by casting the spell over a duration of 10 minutes for each HP that would be otherwise be expended. Casting a spell over time cannot be done in combat, and cannot be used to partially lower the HP cost of a spell. Casting a spell over time does not escape arcane/divine influence.
+A spellcaster may cast spells without expending MP by casting the spell over a duration of 10 minutes for each MP that would be otherwise be expended. Casting a spell over time cannot be done in combat, and cannot be used to partially lower the MP cost of a spell. Casting a spell over time does not escape arcane/divine influence.
 
 Once a spellcaster has cast a spell in an encounter, they enter a state called "arcane (or divine) influence". While in this state, their HP *cannot* be healed normally until they have a short rest. Healing spells cast on an injured caster under arcane/divine influence only heal ¼ of the given amount. Spellcasters automatically exit their influenced state after 1 hour of rest.
 
 There is no need to memorize spells in advance. Just because a character can cast any spell, doesn't mean that they should. Choose spells that suit the character.
 
-Starting at 1st level, select one "signature" spell per spell level that the character prefers to use over any other. These spells are easier to cast due to familiarity, costing 2 HP less to use. Spells that do damage to a target (e.g. _Magic Missile_, _Produce Flame_) always cost at least 1 HP to cast, even if they are a signature spell.
+Starting at 1st level, select one "signature" spell per spell level that the character prefers to use over any other. These spells are easier to cast due to familiarity, costing 2 MP less to use. Spells that do damage to a target (e.g. _Magic Missile_, _Produce Flame_) always cost at least 1 MP to cast, even if they are a signature spell.
 
 ### Casting Metamagic
 
@@ -260,19 +268,19 @@ If a caster is attempting to cast metamagic on their own spell, the metamagic an
 
 Here are some of the most common metamagic spells:
 
-**Extending** makes a spell last twice as long as it normally would. Extending a spell costs 2 HP.
+**Extending** makes a spell last twice as long as it normally would. Extending a spell costs 2 MP.
 
-**Empowering** makes a spell do 50% more damage than normal. Empowering a spell costs 3 HP.
+**Empowering** makes a spell do 50% more damage than normal. Empowering a spell costs 3 MP.
 
-**Widening** makes a spell's area of effect twice as big as normal. Widening a spell costs 4 HP.
+**Widening** makes a spell's area of effect twice as big as normal. Widening a spell costs 4 MP.
 
-**Limiting** makes a spell last half as long as it normally would. Limiting a spell costs 2 HP.
+**Limiting** makes a spell last half as long as it normally would. Limiting a spell costs 2 MP.
 
-**Depowering** makes a spell do 50% less damage than normal. Depowering a spell costs 3 HP.
+**Depowering** makes a spell do 50% less damage than normal. Depowering a spell costs 3 MP.
 
-**Narrowing** makes a spell's area of effect half as large as normal. Narrowing a spell costs 4 HP.
+**Narrowing** makes a spell's area of effect half as large as normal. Narrowing a spell costs 4 MP.
 
-**Attuning** changes the damage type of a spell to a specific element. Attuning a spell costs 3 HP if a material component of the specified element is easily available to the caster; otherwise it costs 5 HP. Spells which already deal elemental damage cannot be Attuned.
+**Attuning** changes the damage type of a spell to a specific element. Attuning a spell costs 3 MP if a material component of the specified element is easily available to the caster; otherwise it costs 5 MP. Spells which already deal elemental damage cannot be Attuned.
 
 If two opposing metamagics are cast on the same spell, they cancel each other out.
 
@@ -281,15 +289,15 @@ If two opposing metamagics are cast on the same spell, they cancel each other ou
 
 *Author's Note:* This section is intended to establish a common baseline for magical items. Gamemasters are encouraged to customize or even ignore this section as needed to fit their setting.
 
-Magical items can be broadly divided into two categories: Active and Passive. Active magical items require some action on the part of the character to make use of their magical effects, while passive items provide their effect at all times. Using an active item may require a skill check of some sort, and may sometimes consume HP in the same fashion spellcasting does.
+Magical items can be broadly divided into two categories: Active and Passive. Active magical items require some action on the part of the character to make use of their magical effects, while passive items provide their effect at all times. Using an active item may require a skill check of some sort, and may require the character to expend MP in the same fashion spellcasting does.
 
 ### Common Active Items:
 
 **Staves:** The main tool of a spellcaster, the staff is a focus used to harness magical energy. Spellcasters usually require a staff to cast a spell. Staves may also contain one or more spells that the caster would not normally have access to; these spells can only be cast while wielding the staff. Spellcasters can create these at 9th level.
 
-**Rods:** Usually employed for easier metamagic, rods may contain a single spell or magical effect. This spell can be cast by anyone for the appropriate HP cost, but non-spellcasting characters do so at +2 or more to the difficulty. Rods with a metamagic effect may be used in tandem with staves when casting a spell. Spellcasters can create these at 5th level.
+**Rods:** Usually employed for easier metamagic, rods may contain a single spell or magical effect. This spell can be cast by anyone for the appropriate MP cost, but non-spellcasting characters do so at +2 or more to the difficulty. Rods with a metamagic effect may be used in tandem with staves when casting a spell. Spellcasters can create these at 5th level.
 
-**Wands:** Sometimes described as "magic-in-a-stick", a wand contains a single spell and a set number of charges. While there are charges left, any character may use the wand to cast the contained spell at the expense of a charge. Wands can be recharged, but usually require a significant HP cost for each charge. Spellcasters can create these at 5th level.
+**Wands:** Sometimes described as "magic-in-a-stick", a wand contains a single spell and a set number of charges. While there are charges left, any character may use the wand to cast the contained spell at the expense of a charge. Wands can be recharged, but usually require a significant MP cost for each charge. Spellcasters can create these at 5th level.
 
 **Potions:** A single-use magical item, potions are a bottled magical liquid. When consumed, a potion confers a magical effect on the character that drank it. Spellcasters can create these at 3rd level.
 
@@ -307,13 +315,13 @@ The process to enchant an item with a magical effect differs slightly from item 
 
 To begin the process, the player needs to have the base form of the item and purchase materials to perform the enchantment, and the spellcaster performing the enchantment must know the spell or use a scroll with the wanted spell. All materials used in the process are consumed, as well as any scrolls used as a source.
 
-The cost of materials used to create a magical item is usually equal to 1/2 the HP cost of the enchantment process, in gold pieces. Thus, infusing a wand with a 1 HP spell would cost 2 gp, 5 sp in materials.
+The cost of materials used to create a magical item is usually equal to 1/2 the MP cost of the enchantment process, in gold pieces. Thus, infusing a wand with a 1 MP spell would cost 2 gp, 5 sp in materials.
 
-The enchantment process will require a spellcaster to infuse the item with HP equal to 5 times the cost of the spell or effect being enchanted with. A spellcaster takes a full hour to infuse 5 HP into an item, and the infusion process places the character under Arcane Influence. No more than one spellcaster may infuse an item at a time.
+The enchantment process will require a spellcaster to infuse the item with MP equal to 5 times the cost of the spell or effect being enchanted with. A spellcaster takes a full hour to infuse 5 MP into an item, and the infusion process places the character under Arcane Influence. No more than one spellcaster may infuse an item at a time.
 
-When creating a scroll or potion, the infusion HP cost is twice the HP cost of the spell being scribed.
+When creating a scroll or potion, the infusion MP cost is twice the MP cost of the spell being scribed.
 
-When creating an item with magical charges, the maximum number of charges the item can hold is determined by `5 + Magic bonus (Mind + Level)`. Each charge requires twice the HP cost of the spell, but the item may be recharged at any point.
+When creating an item with magical charges, the maximum number of charges the item can hold is determined by `5 + Magic bonus (Mind + Level)`. Each charge requires twice the MP cost of the spell, but the item may be recharged at any point.
 
 When the infusion process is finished, the character rolls MIND+Knowledge, and the result of the roll determines the effectiveness of the enchantment.
 
@@ -325,9 +333,9 @@ When the infusion process is finished, the character rolls MIND+Knowledge, and t
 | 15+ | Success! The item is successfully enchanted, and no other effect occurs. |
 | Natural 20 | Critical Success! The item is successfully enchanted, and gains +50% to its effectiveness. |
 
-> **Example:** Your Mage wants to imbue a wand with Prestidigitation. This is a 1st-level Mage spell, so it will take 5 HP to enchant the wand, and 25 sp in material costs. Your Magic bonus is +3, so you decide to infuse it with three of the eight charges to start, bringing the total HP cost to 11.
+> **Example:** Your Mage wants to imbue a wand with Prestidigitation. This is a 1st-level Mage spell, so it will take 5 MP to enchant the wand, and 25 sp in material costs. Your Magic bonus is +3, so you decide to infuse it with three of the eight charges to start, bringing the total MP cost to 11.
 >
->You can only infuse 5 HP per hour, so you must focus on infusing the wand for slightly over two hours. You roll MIND+Knowledge when you have finished infusing the wand and - Presto! - you get a 17! The wand is successfully crafted, holding 3 / 8 charges.
+>You can only infuse 5 MP per hour, so you must focus on infusing the wand for slightly over two hours. You roll MIND+Knowledge when you have finished infusing the wand and - Presto! - you get a 17! The wand is successfully crafted, holding 3 / 8 charges.
 
 ## Resting & Recuperating
 
@@ -338,6 +346,8 @@ After players have been in combat, they may need to rest to regain their stamina
 **Long Rest:** Resting for at least 4 hours constitutes a long rest. A long rest cures most short-term status effects, and is otherwise functionally identical to a short rest.
 
 While resting, characters heal HP equal to `STR bonus + Physical` per hour of rest. Bandages and other healing items usually require that a character take at least a short rest to heal HP. Healing items that require a rest are not affected by arcane/divine influence.
+
+Spellcasters regain MP equal to `MIND bonus + 1d6` per hour of rest. A long rest restores all of a character's Magic Points.
 
 Potions and spells of Cure Wounds instantly heal a character without requiring a rest, but have significantly reduced effect on a character under arcane/divine influence.
 

--- a/src/markdown/microluxe20_handbook.md
+++ b/src/markdown/microluxe20_handbook.md
@@ -42,7 +42,7 @@ Choosing the name is one of the most difficult parts of the process; talk with y
 
 ## Races
 
-Your character's race determines your overall physical appearance and provides a bonus to certain aspects of your character.
+Your character's race determines your overall physical appearance and provides different bonuses to stats and skills.
 
 When creating a character, your player will be one of the major races of Terador. The world has a wealth of races to choose from, each with their unique history. While the Mir are the most common race in Terador, the many other races are fairly commonplace to see as well.
 
@@ -52,11 +52,11 @@ Once you have a name and race, you will need to decide on the physical attribute
 
 ## Vices and Virtues
 
-Designing a backstory and personality for your character is highly recommended. An easy way to start is to pick a vice (a weakness or failing of some sort), a virtue (something your character is good at), and a need or desire.
+When creating a character to roleplay, designing a backstory and personality is highly recommended to help flesh out the narrative and provide a reference point for your portrayal of that character. An easy way to start is to pick a vice (a weakness or failing of some sort), a virtue (something your character is good at), and a need or desire.
 
 These can be anything you would want to roleplay - the character might be proficient with whips, have a crippling fear of snakes, and desire to find hidden treasures; or your character might have an anger issue with the town guard and just wants to be left alone to have a drink. The most interesting stories are created when the Vice or Virtue coincide with the character's desire, forming a conflict of some sort - the area where the treasure is hidden is inhabited by a colony of snakes, or the town guard keeps arresting the character for public drunkenness and disorder.
 
-These factors, when carefully chosen, can significantly help in designing a character that is both interesting and rewarding to roleplay. As a general rule, if your character design is good, your Gamemaster will have numerous opportunities to weave your character's story into the narrative of the adventure; a bad character simply exists, without contributing anything of note to the narrative.
+These factors, when carefully chosen, can help significantly in designing a character that is both interesting and rewarding to roleplay. As a general rule, if your character design is good, your Gamemaster will have numerous opportunities to weave your character's story into the narrative of the adventure; a bad character simply exists, without contributing anything of note to the narrative.
 
 <!-- $page-break -->
 
@@ -254,7 +254,7 @@ Starting at 1st level, select one "signature" spell per spell level that the cha
 
 Metamagic is the name for spells that alter or enhance the effect of another spell, allowing spellcasters to introduce some variety into their existing spells. Metamagic can be cast by any spellcaster, from a rod or as an action, regardless of whether the spellcaster is the one casting the spell being affected.
 
-A Magic Attack roll is not normally required to cast metamagic. However, if the target spell's caster rejects the metamagic being cast on the spell, the metamagic's caster must make a Magic Attack roll to affect the target spell.
+A Magic Attack roll is not normally required to cast metamagic. However, if the target spell's caster rejects the metamagic being cast on the spell, the metamagic's caster must make a Magic Attack roll against the target Spell Difficulty Class to affect the target spell.
 
 If a caster is attempting to cast metamagic on their own spell, the metamagic and the spell must be cast as separate actions, one after the other. This restriction is ignored if the caster is using a rod enchanted with metamagic, or if another caster is casting the metamagic.
 
@@ -266,17 +266,13 @@ Here are some of the most common metamagic spells:
 
 **Widening** makes a spell's area of effect twice as big as normal. Widening a spell costs 4 HP.
 
-**Compelling** adds +5 to the DC for others to alter the spell. Compelling a spell costs 5 HP.
-
-**Dampening** reduces the DC for others to alter the the spell by -5. Dampening a spell costs 5 HP.
-
 **Limiting** makes a spell last half as long as it normally would. Limiting a spell costs 2 HP.
 
 **Depowering** makes a spell do 50% less damage than normal. Depowering a spell costs 3 HP.
 
 **Narrowing** makes a spell's area of effect half as large as normal. Narrowing a spell costs 4 HP.
 
-**Attuning** changes the damage type of a spell to a specific element. Attuning a spell costs 3 HP if the specified element is easily available to the caster; otherwise it costs 5 HP. Spells which already deal elemental damage cannot be Attuned.
+**Attuning** changes the damage type of a spell to a specific element. Attuning a spell costs 3 HP if a material component of the specified element is easily available to the caster; otherwise it costs 5 HP. Spells which already deal elemental damage cannot be Attuned.
 
 If two opposing metamagics are cast on the same spell, they cancel each other out.
 

--- a/src/markdown/microluxe20_handbook.md
+++ b/src/markdown/microluxe20_handbook.md
@@ -92,27 +92,21 @@ After choosing your character's race and class, you will need to set your charac
 
 There are 3 core stats that define a character:
 
-**Strength** (STR): Strength represents the physical prowess of the character. It defines their resilience and toughness as well as how hard they can hit.
+**Strength** (STR): Strength represents the physical prowess of the character. It defines their resilience and toughness as well as how hard they can hit, how much they can carry, and how healthy they are.
 
-**Dexterity** (DEX): Dexterity represents the character's coordination, precision, agility, reflexes, balance and movement.
+**Dexterity** (DEX): Dexterity represents the character's coordination, precision, agility, reflexes, balance and movement. Dexterity controls how accurate a character is with a ranged or thrown weapon.
 
-**Mind** (MIND): Mind represents the character's analytical thinking, as well as their wisdom, memory, knowledge of lore, and general intelligence.
+**Mind** (MIND): Mind represents the character's analytical thinking, as well as their wisdom, memory, knowledge of esoteric lore, and general intelligence. Mind also represents a character's magical competence.
 
 When creating a character, you get 10 points to freely spend on your core stats, as long as no single stat is higher than 6. For example, a Fighter may choose to have 6 STR, 4 DEX, and 0 MIND.
 
 **Stat Bonus:** For any stat, the Stat Bonus is that stat's value divided by two, rounding down. If the stat is negative, round towards negative infinity.
 
-**Hit Points (HP)**: Hit Points determine how healthy a character is. As they are injured or hurt, their HP depletes. To determine a character's starting HP, use the following formula:
+These three primary stats are used to determine several extremely important secondary stats:
+
+**Hit Points (HP)**: Hit Points determine how healthy a character is. As they are injured or hurt, their HP depletes. A character's starting HP is determined with the following formula:
 
 	10 + STR stat + 1d6(with a minimum of 3).
-
-If a player's character is damaged to the point where their HP reaches zero (or below zero), the character becomes "downed", or unconscious and near death, with 0 HP. Further damage directly reduces their normally highest stat (either STR, DEX, or MIND). If that stat drops below -10, the character dies.
-
-While downed, at the start of your turn, roll a d6. You have 3 chances (1 chance per turn) to roll above a 3. If successful, you are stabilized and return to 1 HP. Otherwise, if you are unsuccessful for 3 turns, the character dies. Healing items or spells stabilize downed characters, and the amount healed is restored to the character's HP.
-
-Sometimes damage in combat is dealt directly to a character's Stats instead of Hit Points. If any stat reaches -10 or below, the character is downed and treated as if they were reduced to 0 HP. Damage while downed is applied to the character's next highest Stat instead of the Stat which caused the character to become downed.
-
-Damaged stats will return to their normal levels after a long rest (4 hours).
 
 **Speed** comes in 3 tiers, and determines how far a character can move in a round. Characters are either Slow (20ft.), Normal (30ft.), or Fast (35ft.). A character's Speed is determined by the game master and can be affected by spells and conditions.
 
@@ -121,6 +115,8 @@ Typically, Fighters or Paladins with Heavy armor are Slow, Rogues and Rangers ar
 **Armor Class (AC):** A character's Armor Class represents their ability to evade or block physical attacks. The higher a character's AC, the more difficult it is to land a damaging blow. A character's Armor Class is determined by this formula:
 
 	10 + DEX bonus + Armor bonus + Racial bonus (if applicable).
+
+**Carrying Capacity:** A character's carrying capacity represents the number and weight of items they are able to easily carry without being overburdened. The capacity is equal to `5 + STR bonus`, and can be increased with a backpack.
 
 ## Skills & Saves
 
@@ -137,8 +133,6 @@ The Gamemaster may allow other characters to assist a character when performing 
 **Save Roll** = d20 + stat bonus + situation modifiers
 
 For compatibility purposes, the 3 saves in Microluxe20 (STR save, DEX save, and MIND save), directly match Fortitude, Reflex, and Will saves (often called "saving throws") found in other SRD-based games. Save rolls may not be assisted by other characters.
-
-<!-- $page-break -->
 
 ## Level Advancement
 
@@ -184,6 +178,8 @@ When entering combat, the pace of the game shifts from the free-form nature of e
 
 The order in which characters take their turns in combat is determined by rolling d20 + DEX bonus for **initiative** at the start of each round (ties are settled with a re-roll).
 
+### Attacking and Defending
+
 When making an attack, roll a d20, adding the appropriate **attack bonus** for the action. If the resulting total is greater than your opponent's Armor Class (AC), it's a hit. Natural 20 is automatically a critical, dealing additional damage equal to your weapon's maximum damage.
 
 Melee attack bonuses are used for martial weapons, Ranged attack bonuses are used for thrown and ranged weapons, and Magic attack bonuses are used for spells and magical items with special powers.
@@ -196,9 +192,9 @@ For each attack that hits, roll the damage die code of your weapon or spell, add
 
 > **Example:** Your Human Paladin has hit an enemy Orc with his Greatsword (2d6, Complex). He rolls two six-sided die, getting 4+5 for a total of 9. Since it is a Complex weapon, he adds his strength bonus of +2, for 11 HP damage total. The Orc, having a meager 9 HP left, is killed instantly.
 
-When all characters (including Gamemaster's characters) have taken their turn, the round is over. If there are any opponents left alive or not incapacitated, a new round begins. Otherwise, combat is over.
-
 <!-- $page-break -->
+
+When all characters (including Gamemaster's characters) have taken their turn, the round is over. If there are any opponents left alive or not incapacitated, a new round begins. Otherwise, combat is over.
 
 ## Special Combat Rules
 
@@ -220,17 +216,33 @@ Attempting to knock out, restrain, or trip a hostile character with an attack is
 
 Characters wielding a Complex melee weapon in one hand add their STR bonus to the damage total. Characters wielding a Two-Handed melee weapon add 1½ times their STR bonus to the damage total.
 
+### Unconsciousness and Death
+
+If a player's character is damaged to the point where their HP reaches zero (or below zero), the character becomes "downed", or unconscious and near death, with 0 HP. Further damage directly reduces their normally highest stat (either STR, DEX, or MIND). If that stat drops below -10, the character dies.
+
+Unless the Game Master decides otherwise, monsters and non-player characters die when brought to zero HP.
+
+Each turn while downed, roll a d6 at the start of your turn. If you roll above a 3, you are stabilized and return to 1 HP. Otherwise, if you are unsuccessful for 3 turns, your character dies. Healing items or spells will stabilize downed characters, and they restore a character's HP as normal.
+
+Some attacks drain a specific Stat instead of HP. If a character has one of their stats drained to -10 or below, the character is downed and treated as if they were reduced to 0 HP. Damage while downed is applied to the character's next highest Stat instead of the Stat which caused the character to become downed.
+
+All stat damage taken while downed or in combat is restored after 24 hours have elapsed and the character takes a long rest.
+
+<!-- $page-break -->
+
 ## Spells
 
 Spellcasters may cast any of their class spells as long as the spell level is equal to or below their class level. When casting a spell, characters make a Magic Attack, rolling 1d20 + Magic Attack Bonus. If the resulting roll is greater than the Spell Difficulty Class, the spell is successfully cast.
 
-**Spell Difficulty Class (DC):** 10 (or spell-specific difficulty) + Target's MIND stat
+**Spell Difficulty Class (DC):** 10 (or spell-specific difficulty) + Spell Level + Target's MIND Bonus
 
-When a spell is successfully cast, the spell immediately takes effect, unless the spell states that the target may make a specific save against the spell's effects. For example, a spell that forms spikes that protrude from the ground may allow the target to make a DEX save to try and escape the spell.
+When casting a spell against an inanimate object, the target's MIND bonus is not considered part of the DC.
 
-Casting a spell of any kind, regardless of the outcome, costs Hit Points. The cost is equal to the level of the spell being cast. For example, a 2nd level spell will cost the caster 2 HP.
+If the spell is successfully cast it immediately takes effect, unless the spell states that the target may make a specific save against the spell's effects. For example, a spell that forms spikes that protrude from the ground may allow the target to make a DEX save to try and escape the spell.
 
-A spellcaster may cast spells without expending HP by casting the spell over a duration of 10 minutes for each HP that would be otherwise be expended. Spells cannot be partially cast over time for a reduced HP cost, and casting a spell over time does not escape arcane/divine influence.
+Casting a spell of any kind costs Hit Points, regardless of the outcome. The cost is equal to the level of the spell being cast. For example, a 2nd level spell will cost the caster 2 HP.
+
+A spellcaster may cast spells without expending HP by casting the spell over a duration of 10 minutes for each HP that would be otherwise be expended. Casting a spell over time cannot be done in combat, and cannot be used to partially lower the HP cost of a spell. Casting a spell over time does not escape arcane/divine influence.
 
 Once a spellcaster has cast a spell in an encounter, they enter a state called "arcane (or divine) influence". While in this state, their HP *cannot* be healed normally until they have a short rest. Healing spells cast on an injured caster under arcane/divine influence only heal ¼ of the given amount. Spellcasters automatically exit their influenced state after 1 hour of rest.
 
@@ -246,13 +258,28 @@ A Magic Attack roll is not normally required to cast metamagic. However, if the 
 
 If a caster is attempting to cast metamagic on their own spell, the metamagic and the spell must be cast as separate actions, one after the other. This restriction is ignored if the caster is using a rod enchanted with metamagic, or if another caster is casting the metamagic.
 
-Here are the three most common metamagic spells:
+Here are some of the most common metamagic spells:
 
-- **Extending** makes a spell last twice as long as it normally would. Extending a spell costs 2 HP.
+**Extending** makes a spell last twice as long as it normally would. Extending a spell costs 2 HP.
 
-- **Empowering** makes a spell do 50% more damage than normal. Empowering a spell costs 4 HP.
+**Empowering** makes a spell do 50% more damage than normal. Empowering a spell costs 3 HP.
 
-- **Widening** makes a spell's area of effect twice as big as normal. Widening a spell costs 6 HP.
+**Widening** makes a spell's area of effect twice as big as normal. Widening a spell costs 4 HP.
+
+**Compelling** adds +5 to the DC for others to alter the spell. Compelling a spell costs 5 HP.
+
+**Dampening** reduces the DC for others to alter the the spell by -5. Dampening a spell costs 5 HP.
+
+**Limiting** makes a spell last half as long as it normally would. Limiting a spell costs 2 HP.
+
+**Depowering** makes a spell do 50% less damage than normal. Depowering a spell costs 3 HP.
+
+**Narrowing** makes a spell's area of effect half as large as normal. Narrowing a spell costs 4 HP.
+
+**Attuning** changes the damage type of a spell to a specific element. Attuning a spell costs 3 HP if the specified element is easily available to the caster; otherwise it costs 5 HP. Spells which already deal elemental damage cannot be Attuned.
+
+If two opposing metamagics are cast on the same spell, they cancel each other out.
+
 
 ## Magic Items
 
@@ -271,8 +298,6 @@ Magical items can be broadly divided into two categories: Active and Passive. Ac
 **Potions:** A single-use magical item, potions are a bottled magical liquid. When consumed, a potion confers a magical effect on the character that drank it. Spellcasters can create these at 3rd level.
 
 **Scrolls:** Scrolls are small sheets of parchment that allow any character to cast a single spell simply by saying the text out loud. Reading a scroll does not require a character to understand the language it is written in, and completely destroys it. Spellcasters may use Read Magic to decipher a scroll without casting (and destroying) it. Spellcasters can create these at 1st level.
-
-<!-- $page-break -->
 
 ### Common Passive Items:
 
@@ -308,8 +333,6 @@ When the infusion process is finished, the character rolls MIND+Knowledge, and t
 >
 >You can only infuse 5 HP per hour, so you must focus on infusing the wand for slightly over two hours. You roll MIND+Knowledge when you have finished infusing the wand and - Presto! - you get a 17! The wand is successfully crafted, holding 3 / 8 charges.
 
-<!-- $page-break -->
-
 ## Resting & Recuperating
 
 After players have been in combat, they may need to rest to regain their stamina. There are 2 forms of resting:
@@ -322,9 +345,43 @@ While resting, characters heal HP equal to `STR bonus + Physical` per hour of re
 
 Potions and spells of Cure Wounds instantly heal a character without requiring a rest, but have significantly reduced effect on a character under arcane/divine influence.
 
+<!-- $page-break -->
+
 ## Heroism
 
 **Heroism** is intended to relieve some of the power incompatibilities with some d20 adventure types. If you find that the party is consistently too weak, try adding Heroism. **Heroism** is a bonus equal to the character's level that may be applied to an Attack Bonus, Damage roll, Saving Throw, or Skill Check. Heroism may be used up to three times per day.
+
+## Light
+
+The lighting conditions of an area have a subtle but important effect on a character. The precise details are up to the Gamemaster, but for convenience this handbook divides lighting conditions into three broad categories:
+
+**Bright:** Lit by the sun, a bright lamp, or a spell of Light, you can see clearly and discern fine detail. All actions are taken as normal.
+
+**Dim:** A flickering candle or a dim lantern casts light here; characters can't see beyond medium range and have a difficult time making out details. In Dim lighting, all attack rolls take a -1 or greater penalty, and skill checks involving perception or detailed work take a -2 to -4 penalty.
+
+**Dark:** New moon or the inside of a cave; most characters cannot see anything beyond short range, and determining detail is almost impossible. All attack rolls take a -4 or greater penalty, and affected skill checks fail at the Gamemaster's discretion.
+
+## Range
+
+Instead of a tabletop grid system, Microluxe20 uses narrative ranges determined by the Game Master. Five ranges are used throughout the handbook: **Self**, **Touch**, **Short**, **Medium**, and **Long**. Self refers to only your character and any items or clothing you are holding or wearing. The other ranges correspond to a maximum distance according to the table below:
+
+| Range:   | Touch: | Short: | Medium: | Long:   |
+| :-----   | :----- | :----- | :------ | :----   |
+| Distance | < 5ft. | 30 ft. | 120 ft. | 480 ft. |
+
+## Inventory Size and Weight
+
+**Bulk** determines how many items a character can carry on their person or in their inventory. Items are classified according to their size and weight into one of four size classes:
+
+- **Tiny** items that can be stacked together like arrows or coins count for 1 Bulk for every 20 items.
+- **Small** items can be comfortably held in one hand, like daggers, loaves of bread, or potions, and  count for 1 Bulk.
+- **Medium** items are the size of a normal arm, like long swords, bows, or bedrolls, and count for 3 Bulk.
+- **Large** items are the size of a torso, like a tower shield, empty barrels, or a full set of armor, and count for 5 Bulk.
+
+Anything larger is left to the Game Master's discretion as to whether a character is capable of even lifting it.
+
+A character's Carry Capacity determines how much Bulk they can carry without being overburdened. Backpacks, satchels, and other containers can increase the character's capacity. An overburdened character takes -1 to all Dex checks and attack rolls for each point of Bulk they are overburdened by.
+
 
 # Appendix
 

--- a/src/markdown/microluxe20_handbook.md
+++ b/src/markdown/microluxe20_handbook.md
@@ -184,21 +184,41 @@ When entering combat, the pace of the game shifts from the free-form nature of e
 
 The order in which characters take their turns in combat is determined by rolling d20 + DEX bonus for **initiative** at the start of each round (ties are settled with a re-roll).
 
-When making an attack, roll a d20, adding the appropriate **attack bonus** for the action. If the resulting total is greater than your opponent's Armor Class (AC), it's a hit. Natural 20 is automatically a critical, dealing additional damage equal to your weapon's maximum damage. Melee attack bonuses are used for martial weapons, Missile attack bonuses are used for ranged combat, and Magic attack bonuses are used for staves and other magical items with special powers.
+When making an attack, roll a d20, adding the appropriate **attack bonus** for the action. If the resulting total is greater than your opponent's Armor Class (AC), it's a hit. Natural 20 is automatically a critical, dealing additional damage equal to your weapon's maximum damage.
 
-| **Melee Attack Bonus:** | **Missile Attack Bonus:** | **Magic Attack Bonus:** |
+Melee attack bonuses are used for martial weapons, Ranged attack bonuses are used for thrown and ranged weapons, and Magic attack bonuses are used for spells and magical items with special powers.
+
+| **Melee Attack Bonus:** | **Ranged Attack Bonus:** | **Magic Attack Bonus:** |
 | :- | :- | :- |
 | STR bonus + Character Level | DEX bonus + Character Level | MIND bonus + Character Level |
 
-If a character's attack bonus is +6 or more, they can make an additional attack ("sub-attack") by subtracting -5 for the new attack's bonus. This can be carried out up to three times. For example, if the total bonus is +12, the character can make two sub-attacks for a total of three attacks (at +12/+7/+2, respectively). Sub-attacks cannot deal critical damage.
-
-Fighters and Rogues may use DEX bonus + Level (Missile attack bonus) as their Melee attack bonus when wielding a light weapon. Fighters, Rogues, Bards, and Rangers may wield 2 light weapons and attack with both in a round, if they take a -2 penalty on all attack rolls that round. Rangers take a -1 penalty instead.
-
-For each attack that hits, roll the damage die code on your weapon and subtract the resulting total from your opponent's HP. When wielding a Complex Melee weapon, add your STR bonus to the damage total.
+For each attack that hits, roll the damage die code of your weapon or spell, adding any bonuses from your class or weapon, and subtract the resulting total from your opponent's HP. An attack that hit always deals at least 1 damage.
 
 > **Example:** Your Human Paladin has hit an enemy Orc with his Greatsword (2d6, Complex). He rolls two six-sided die, getting 4+5 for a total of 9. Since it is a Complex weapon, he adds his strength bonus of +2, for 11 HP damage total. The Orc, having a meager 9 HP left, is killed instantly.
 
 When all characters (including Gamemaster's characters) have taken their turn, the round is over. If there are any opponents left alive or not incapacitated, a new round begins. Otherwise, combat is over.
+
+<!-- $page-break -->
+
+## Special Combat Rules
+
+While the basics of combat apply in all situations, some players may want to do more than just wield a single weapon or make a normal attack every turn. These rules are designed to allow players greater freedom in their playstyle.
+
+**Fighters**, **Rogues**, **Rangers**, and **Bards** may wield 2 light weapons and attack with both in a round, if they take a -2 penalty on all attack rolls that round. Rangers take a -1 penalty instead.
+
+**Fighters** and **Rogues** may use their Ranged Attack bonus (DEX + Level) instead of their Melee Attack bonus (STR + Level) when attacking with a Light melee weapon.
+
+If a character's attack bonus is +6 or more, they can make an additional strike or fire another projectile at the same target (a "sub-attack") by taking a -5 penalty to each attack's bonus. This can be carried out up to three times, so long as the resulting attack bonus is +1 or more.
+
+> **Example:** if your character's total Melee Attack bonus is +12, you can choose to strike three times (at +2/+2/+2), twice (at +7/+7), or once at +12. However, you can't split the strikes up between different targets.
+
+When a character enters or exits the melee range of a hostile character, the hostile character may be able to attack them, at the GM's discretion. This is called an Attack of Opportunity, and is carried out like a normal attack. Characters unable to take a normal combat action may not make an Attack of Opportunity.
+
+Attempting to attack a specific part of a hostile character or target is known as a Called Shot, and is made at a -2 or greater penalty to Attack bonus. Successfully hitting a Called Shot may have special effects such as wounding or incapacitating the target, or may simply act like a normal attack, as determined by the GM.
+
+Attempting to knock out, restrain, or trip a hostile character with an attack is considered a Called Shot, with appropriate penalties to Attack bonus as determined by the GM.
+
+Characters wielding a Complex melee weapon in one hand add their STR bonus to the damage total. Characters wielding a Two-Handed melee weapon add 1½ times their STR bonus to the damage total.
 
 ## Spells
 
@@ -234,8 +254,6 @@ Here are the three most common metamagic spells:
 
 - **Widening** makes a spell's area of effect twice as big as normal. Widening a spell costs 6 HP.
 
-<!-- $page-break -->
-
 ## Magic Items
 
 *Author's Note:* This section is intended to establish a common baseline for magical items. Gamemasters are encouraged to customize or even ignore this section as needed to fit their setting.
@@ -248,11 +266,13 @@ Magical items can be broadly divided into two categories: Active and Passive. Ac
 
 **Rods:** Usually employed for easier metamagic, rods may contain a single spell or magical effect. This spell can be cast by anyone for the appropriate HP cost, but non-spellcasting characters do so at +2 or more to the difficulty. Rods with a metamagic effect may be used in tandem with staves when casting a spell. Spellcasters can create these at 5th level.
 
-**Wands:** Sometimes described as "magic-in-a-bottle", a wand contains a combination of a single spell and a set amount of charges. While there are charges left, any character may use the wand to cast the contained spell at the expense of a charge. Wands can be recharged, but usually require a significant HP cost for each charge. Spellcasters can create these at 5th level.
+**Wands:** Sometimes described as "magic-in-a-stick", a wand contains a single spell and a set number of charges. While there are charges left, any character may use the wand to cast the contained spell at the expense of a charge. Wands can be recharged, but usually require a significant HP cost for each charge. Spellcasters can create these at 5th level.
 
 **Potions:** A single-use magical item, potions are a bottled magical liquid. When consumed, a potion confers a magical effect on the character that drank it. Spellcasters can create these at 3rd level.
 
-**Scrolls:** Scrolls are small sheets of parchment that allow any character to cast a single spell simply by saying the text out loud. Reading the Scroll does not require a character to understand the language it is written in, and completely destroys the scroll. Spellcasters may use Read Magic to decipher a scroll without casting (and destroying) it. Spellcasters can create these at 1st level.
+**Scrolls:** Scrolls are small sheets of parchment that allow any character to cast a single spell simply by saying the text out loud. Reading a scroll does not require a character to understand the language it is written in, and completely destroys it. Spellcasters may use Read Magic to decipher a scroll without casting (and destroying) it. Spellcasters can create these at 1st level.
+
+<!-- $page-break -->
 
 ### Common Passive Items:
 
@@ -287,6 +307,8 @@ When the infusion process is finished, the character rolls MIND+Knowledge, and t
 > **Example:** Your Mage wants to imbue a wand with Prestidigitation. This is a 1st-level Mage spell, so it will take 5 HP to enchant the wand, and 25 sp in material costs. Your Magic bonus is +3, so you decide to infuse it with three of the eight charges to start, bringing the total HP cost to 11.
 >
 >You can only infuse 5 HP per hour, so you must focus on infusing the wand for slightly over two hours. You roll MIND+Knowledge when you have finished infusing the wand and - Presto! - you get a 17! The wand is successfully crafted, holding 3 / 8 charges.
+
+<!-- $page-break -->
 
 ## Resting & Recuperating
 

--- a/src/markdown/microluxe20_handbook.md
+++ b/src/markdown/microluxe20_handbook.md
@@ -64,29 +64,29 @@ These factors, when carefully chosen, can significantly help in designing a char
 
 Classes define your character's way of life. Your character's class helps shape his/her combat style and methods of overcoming various obstacles. Your class provides a pathway, granting special powers and features for your character.
 
-**Fighters** wear and use any kind of armor, shield, and weapon. They gain a +3 bonus to Physical and add +1 to all attack and damage rolls. This increases by +1 at 5th level and every five levels onward. They also gain additional HP equal to their STR bonus every time they level up. Fighters gain the _Cleave_ ability at level 5. If the Fighter's melee attack drops/slays a foe, the fighter gets one additional attack against another opponent within range. This ability can compound, meaning if one swing kills the second foe, the Fighter can continue to attack until he/she either misses or doesn't kill the foe with the attack.
+A simple overview of the available classes is listed here. For full details, see the chapter on _Classes, Spells and Powers_.
 
-**Rogues** can use light armor, can use bucklers, and can use simple weapons and complex light weapons. They have a +3 bonus to Guile. Rogues can _Sneak Attack_. If they successfully sneak (usually Guile+DEX, but depends on situation) up on a foe they can add their Guile skill rank to the damage of their first attack. Rogues gain the _Evade_ ability at level 5. Any save that a rogue succeeds cannot deal damage to the rogue. For example, some spells deal half-damage even if the target saves successfully. With Evade, the rogue would not take any damage as long as he/she saved successfully.
+**Fighters** wear and use any kind of armor, shield, and weapon. They gain a +3 bonus to Physical and add +1 to all attack and damage rolls, increasing by +1 at every 5th level. They also gain additional HP (based on STR) when they level up.
+
+**Rogues** can use light armor, can use bucklers, and can use simple weapons and complex light weapons. They have a +3 bonus to Guile. Rogues can _Sneak Attack_ with a successful stealth roll (usually Guile+DEX), and gain the _Evade_ ability at level 5.
 
 **Mages** wear no armor, can not use shields, and can use simple weapons. They can cast arcane spells (Mage), and gain a +3 bonus to Knowledge.
 
-**Clerics** can wear light or medium armor, can not use shields, and can use simple weapons. They cast divine spells (Cleric) and gain a +3 bonus to Communication. A Cleric can _Turn Undead_ with a successful Magic Attack. The DC for the action is the current HP of the Undead. If the DC is exceeded by 10 it is destroyed. This can be used (2 + Level + MIND Bonus) times per day.
+**Clerics** can wear light or medium armor, can not use shields, and can use simple weapons. They cast divine spells (Cleric) and gain a +3 bonus to Communication. A Cleric can _Turn Undead_ with a successful Magic Attack.
 
-**Paladins** wear and use any kind of armor, shield, and weapon. They gain +1 to Physical and a +2 bonus to Communication. They are immune to diseases and apply a +1 bonus to all saving throws (this increases by +1 at 5th level and every 5 levels onward). Paladins can _Detect Evil_ within 60 ft. at will and can heal up to 2 HP per level up to three times per day by _Laying on Hands_. _Laying on Hands_ ignores Arcane and Divine Influence on casters, healing the full amount.
+**Paladins** wear and use any kind of armor, shield, and weapon. They gain +1 to Physical and a +2 bonus to Communication. Paladins can _Detect Evil_ and heal others by _Laying on Hands_, and gain _Divine Favor_ at level 5.
 
-**Rangers** wear light or medium armor, can use shields, and can use simple weapons, complex ranged weapons, and complex one-handed weapons. They gain +1 to hit and +1 damage with ranged weapons and only incur a -1 to hit penalty when fighting with 2 weapons. They have a +1 bonus to Guile and a +2 bonus to Physical. Rangers gain the _Trapper_ ability at level 5. When dealing with trap-related dice rolls (such as dodging a trap or searching for traps), a ranger gains a +2 bonus.
+**Rangers** wear light or medium armor, can use shields, and can use simple weapons, complex ranged weapons, and complex one-handed weapons. They gain a +1 bonus to Guile and a +2 bonus to Physical. They have +1 to ranged weapon rolls and incur less of a penalty for fighting with 2 weapons. Rangers gain the _Trapper_ ability at level 5.
 
 **Illusionists** wear no armor, can not use shields, and can use simple weapons. They can cast arcane spells (Illusionist) and gain a +2 bonus to Communication and a +1 bonus to Guile.
 
-**Druids** wear any non-metal armor, can use non-metal shields, and can use simple weapons. They cast divine spells (Druid) and gain +2 to Knowledge and +1 to Physical. Druids are immune to the spell-like effects of woodland fey. At 3rd level a Druid can _Pass Without Trace_ (be untraceable) at will. At 7th level a Druid can assume the form of any small or medium sized animal up to 3 times per day. A Druid heals 2 HP per level when changing back into his/her human form.
+**Druids** wear any non-metal armor, can use non-metal shields, and can use simple weapons. They cast divine spells (Druid) and gain +2 to Knowledge and +1 to Physical. Druids are immune to the effects of woodland fey, can _Pass Without Trace_ at 3rd level, and take the form of a small or medium sized animal at 7th level.
 
-**Bards** wear light armor, can use bucklers, and can use simple weapons and complex light weapons. They gain +2 to Communication and +1 to Guile. A Bard has the _Performance_ ability, allowing him/her to counter sound-based effects within a 30 ft. radius. A Bard can use his/her song to _Charm Person_ or _Remove Fear_ (vs DC) up to 3 times (total) per day. Beginning at 6th level, a Bard casts spells as either a Druid or Illusionist (player's choice) of 5 levels lower.
+**Bards** wear light armor, can use bucklers, and can use simple weapons and complex light weapons. They gain +2 to Communication and +1 to Guile. A Bard can counter sound-based effects with _Performance_, and can _Charm Person_ or _Remove Fear_ with a successful skill roll. A Bard can also cast spells as either a Druid or Illusionist of 5 levels lower.
 
 **Psions** can use light armor, can not use shields, and can use simple weapons. They can manifest Psion powers and gain +2 to Knowledge and +1 to Communication.
 
-After choosing your character's race and class, you will need to configure your stats and skills.
-
-<!-- $page-break -->
+After choosing your character's race and class, you will need to set your character's starting Stats and Skills.
 
 ## Stats
 
@@ -138,6 +138,8 @@ The Gamemaster may allow other characters to assist a character when performing 
 
 For compatibility purposes, the 3 saves in Microluxe20 (STR save, DEX save, and MIND save), directly match Fortitude, Reflex, and Will saves (often called "saving throws") found in other SRD-based games. Save rolls may not be assisted by other characters.
 
+<!-- $page-break -->
+
 ## Level Advancement
 
 Characters gain XP (or Experience Points) from defeating monsters, disarming traps, or from handling situations in innovative ways, at the GM's discretion. XP is awarded to all characters who take part in the encounter.
@@ -188,7 +190,7 @@ When making an attack, roll a d20, adding the appropriate **attack bonus** for t
 | :- | :- | :- |
 | STR bonus + Character Level | DEX bonus + Character Level | MIND bonus + Character Level |
 
-While a character's attack bonus is +6 or more, they can make an additional attack by subtracting -5 for the new attack's bonus. This can be carried out up to three times. For example, if the total bonus is +12, three attacks can be made (at +12/+7/+2, respectively).
+If a character's attack bonus is +6 or more, they can make an additional attack ("sub-attack") by subtracting -5 for the new attack's bonus. This can be carried out up to three times. For example, if the total bonus is +12, the character can make two sub-attacks for a total of three attacks (at +12/+7/+2, respectively). Sub-attacks cannot deal critical damage.
 
 Fighters and Rogues may use DEX bonus + Level (Missile attack bonus) as their Melee attack bonus when wielding a light weapon. Fighters, Rogues, Bards, and Rangers may wield 2 light weapons and attack with both in a round, if they take a -2 penalty on all attack rolls that round. Rangers take a -1 penalty instead.
 
@@ -214,7 +216,7 @@ Once a spellcaster has cast a spell in an encounter, they enter a state called "
 
 There is no need to memorize spells in advance. Just because a character can cast any spell, doesn't mean that they should. Choose spells that suit the character.
 
-Starting at 1st level, select one "signature" spell per spell level that the character prefers to use over any other. These spells are easier to cast due to familiarity, costing 2 HP less to use.
+Starting at 1st level, select one "signature" spell per spell level that the character prefers to use over any other. These spells are easier to cast due to familiarity, costing 2 HP less to use. Spells that do damage to a target (e.g. _Magic Missile_, _Produce Flame_) always cost at least 1 HP to cast, even if they are a signature spell.
 
 ### Casting Metamagic
 
@@ -290,13 +292,13 @@ When the infusion process is finished, the character rolls MIND+Knowledge, and t
 
 After players have been in combat, they may need to rest to regain their stamina. There are 2 forms of resting:
 
-**Short Rest:** Resting for 1-4 hours constitutes a short rest. Characters heal up to ¼ of their Max HP (rounded up). Spellcasters are no longer under arcane/divine influence.
+**Short Rest:** Resting for at least an hour constitutes a short rest. Spellcasters are no longer under arcane/divine influence once they have taken a short rest.
 
-**Long Rest:** Resting for at least 4 hours constitutes a long rest. Characters heal all of their HP and short-term side effects. Spellcasters also lose their arcane/divine influence.
+**Long Rest:** Resting for at least 4 hours constitutes a long rest. A long rest cures most short-term status effects, and is otherwise functionally identical to a short rest.
 
-Resting for less than 4 hours recovers at most ¼ of a character's HP, regardless of the duration of the rest. Downed characters must be stabilized before they can rest.
+While resting, characters heal HP equal to `STR bonus + Physical` per hour of rest. Bandages and other healing items usually require that a character take at least a short rest to heal HP. Healing items that require a rest are not affected by arcane/divine influence.
 
-After resting, characters may not rest again until they have lost ¼ of their total HP, or one hour has passed.
+Potions and spells of Cure Wounds instantly heal a character without requiring a rest, but have significantly reduced effect on a character under arcane/divine influence.
 
 ## Heroism
 

--- a/src/markdown/microluxe20_handbook.md
+++ b/src/markdown/microluxe20_handbook.md
@@ -160,7 +160,7 @@ Regardless of how they are awarded, each level adds:
 
 * Spellcasters gain additional Magic Points equal to 1d3 + MIND bonus.
 
-* +2 points to spend on skills. When upgrading skills, you cannot add more points to a skill if it is equal to or higher than your character's level + 5.
+* +2 points to spend on skills. When upgrading skills, you cannot add more points to a skill if it is equal to or higher than your character's level.
 
 * Every 3rd level (3, 6, 9, 12, etc.), characters gain +1 STR, DEX, or MIND.
 
@@ -216,7 +216,7 @@ If a character's attack bonus is +6 or more, they can make an additional strike 
 
 > **Example:** if your character's total Melee Attack bonus is +12, you can choose to strike three times (at +2/+2/+2), twice (at +7/+7), or once at +12. However, you can't split the strikes up between different targets.
 
-When a character enters or exits the melee range of a hostile character, the hostile character may be able to attack them, at the GM's discretion. This is called an Attack of Opportunity, and is carried out like a normal attack. Characters unable to take a normal combat action may not make an Attack of Opportunity.
+When a character exits the melee range of a hostile character, the hostile character may be able to attack them, at the GM's discretion. This is called an Attack of Opportunity, and is carried out like a normal attack. Characters unable to take a normal combat action may not make an Attack of Opportunity.
 
 Attempting to attack a specific part of a hostile character or target is known as a Called Shot, and is made at a -2 or greater penalty to Attack bonus. Successfully hitting a Called Shot may have special effects such as wounding or incapacitating the target, or may simply act like a normal attack, as determined by the GM.
 
@@ -345,7 +345,7 @@ After players have been in combat, they may need to rest to regain their stamina
 
 **Long Rest:** Resting for at least 4 hours constitutes a long rest. A long rest cures most short-term status effects, and is otherwise functionally identical to a short rest.
 
-While resting, characters heal HP equal to `STR bonus + Physical` per hour of rest. Bandages and other healing items usually require that a character take at least a short rest to heal HP. Healing items that require a rest are not affected by arcane/divine influence.
+While resting, characters heal HP equal to `STR bonus + 1d8` per hour of rest. Bandages and other healing items usually require that a character take at least a short rest to heal HP. Healing items that require a rest are not affected by arcane/divine influence.
 
 Spellcasters regain MP equal to `MIND bonus + 1d6` per hour of rest. A long rest restores all of a character's Magic Points.
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -87,7 +87,7 @@ ul, ol {
     padding-left: 1.6em;
 }
 
-li > p {
+ul p {
     display: inline;
 }
 
@@ -109,6 +109,7 @@ blockquote, pre {
 blockquote {
     margin-left: 0;
     margin-right: 0;
+    page-break-inside: avoid;
 }
 
 /* Collapse margin where padding makes it redundant. */


### PR DESCRIPTION
 ### Unified class list, added healing items, clarified sub-attacks, and more
- Added herbal tea, bandages, and rules for healer's kit.
- Made rests heal at a more appropriate rate, to give healing items a 
role.
- Removed "free magic attack" behavior to balance spellcasters.
- Clarified and removed criticals on sub-attacks.
- Unified class descriptions and abilities with spell lists, and 
clarified certain abilities.
- Made certain 1st-level spells a class ability instead.
- Gave Paladins a minor spellcasting ability with Divine Favor.
- Minor balance and flavor changes.

### Add metamagic, range, light, and bulk rules.

- Rebalanced metamagic costs. Now metamagic costs 1-2 HP less.
- Stat drain takes a long rest and a full day to recover from.
- Added carrying capacity secondary stat.

The following changes are thanks to JohnG on Discord:
- Added new counter metamagics
- Added 'Attune' metamagic as the start of an elemental damage system
- Added rules for Light, Range, and Bulk

